### PR TITLE
Transform Hotfix + Bug Fixes

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -22,7 +22,7 @@ If possible, including the following would be **immensely** helpful!
 
 * **OS** (e.g., Windows, macOS, Android, etc.)
 * **Browser** (e.g., Chrome, Firefox, etc.)
-* **Showdex Version** (e.g., v1.1.3)
+* **Showdex Version** (e.g., v1.1.4)
 * **Format**, if applicable (e.g., Gen 9 National Dex AG)
 
 If you would like to be [credited for your contribution](../README.md#contributors), please also include your username on [**Smogon Forums**](https://smogon.com/forums). Otherwise, your **GitHub** username will be used, unless you don't want to be credited.

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 <table align="center">
   <thead>
     <tr>
-      <th align="center">&nbsp;Current <a href="https://github.com/doshidak/showdex/releases/tag/v1.1.3">v1.1.3</a>&nbsp;</th>
+      <th align="center">&nbsp;Current <a href="https://github.com/doshidak/showdex/releases/tag/v1.1.4">v1.1.4</a>&nbsp;</th>
       <th align="center">&nbsp;Install on <a href="https://chrome.google.com/webstore/detail/dabpnahpcemkfbgfbmegmncjllieilai">Chrome · Opera · Edge · Brave</a> · <a href="https://addons.mozilla.org/en-US/firefox/addon/showdex">Firefox</a> · <a href="https://apps.apple.com/us/app/enhanced-tooltips-for-showdown/id1612964050">Safari</a>&nbsp;</th>
-      <th align="center">&nbsp;Discuss on <a href="https://www.smogon.com/forums/threads/showdex-an-auto-updating-damage-calculator-built-into-showdown.3707265">Smogon</a></th>
+      <th align="center">&nbsp;Discuss on <a href="https://smogon.com/forums/threads/showdex-an-auto-updating-damage-calculator-built-into-showdown.3707265">Smogon</a></th>
     </tr>
   </thead>
 </table>
@@ -211,7 +211,7 @@ You'll need to apply some slight tweaks to your browser in order to directly ins
 
   > This runs [**`patch-package`**](https://github.com/ds300/patch-package), which reads from the [**`patches`**](./patches) directory and applies the `diff` to the corresponding package in *your* `node_modules`.
   >
-  > [Patch for `@smogon/calc`](./patches/%40smogon%2Bcalc%2B0.7.0.patch) incorporates all the changes up to the [`77334fa`](https://github.com/smogon/damage-calc/commit/77334fa0babdfb8cd49076d8c5ee7eff8d2bede8) commit, which adds support for Gen 9 & implements some Gen 9-specific mechanics, such as [*Supreme Overlord*](https://smogon.com/dex/sv/abilities/supreme-overlord). These changes are unpublished on [npm](https://npmjs.com/package/@smogon/calc) as Gen 9 support in `@smogon/calc` is considered experimental (at the time of writing on 2023/01/06). Not all Gen 9 mechanics are supported however, such as [*Rage Fist*](https://smogon.com/dex/sv/moves/rage-fist), [*Glaive Rush*](https://www.smogon.com/dex/sv/moves/glaive-rush) & [*Electromorphosis*](https://smogon.com/dex/sv/abilities/electromorphosis), so the Calcdex will handle these mechanics until native support for them are added. Additionally, the patch adds support for independently toggling the [*Protosynthesis*](https://smogon.com/dex/sv/abilities/protosynthesis) & [*Quark Drive*](https://smogon.com/dex/sv/abilities/quark-drive) abilities without the need for the [*Booster Energy*](https://smogon.com/dex/sv/items/booster-energy) item or updating field conditions, which can affect damage calculations (e.g., [*Knock Off*](https://smogon.com/dex/sv/moves/knock-off), [*Acrobatics*](https://smogon.com/dex/sv/moves/acrobatics), [Fire/Water-type moves from the Sun](https://smogon.com/dex/sv/moves/sunny-day)).
+  > [Patch for `@smogon/calc`](./patches/%40smogon%2Bcalc%2B0.7.0.patch) incorporates all the changes up to the [`262e6a2`](https://github.com/smogon/damage-calc/commit/262e6a2c155f27fb3790946494519fbdff02ed6e) commit, which adds support for Gen 9. These changes are unpublished on [npm](https://npmjs.com/package/@smogon/calc) as Gen 9 support in `@smogon/calc` is considered experimental (at the time of writing on 2023/01/06). Not all Gen 9 mechanics are supported however, so the Calcdex will handle some of these mechanics until native support for them are added. Additionally, the patch adds support for independently toggling the [*Protosynthesis*](https://smogon.com/dex/sv/abilities/protosynthesis) & [*Quark Drive*](https://smogon.com/dex/sv/abilities/quark-drive) abilities without the need for the [*Booster Energy*](https://smogon.com/dex/sv/items/booster-energy) item or updating field conditions, which can affect damage calculations (e.g., [*Knock Off*](https://smogon.com/dex/sv/moves/knock-off), [*Acrobatics*](https://smogon.com/dex/sv/moves/acrobatics), [Fire/Water-type moves from the Sun](https://smogon.com/dex/sv/moves/sunny-day)).
   >
   > [Patch for `react-select`](./patches/react-select%2B5.4.0.patch) wraps the [`scrollIntoView()` call in the `componentDidUpdate()` of the `Select` component](https://github.com/JedWatson/react-select/blob/4b8468636bcfadf0cfe45f9a7a6c1db5dca08d9a/packages/react-select/src/Select.tsx#L735-L743) in a `setTimeout()` so that the internal [`menuListRef`](https://github.com/JedWatson/react-select/blob/4b8468636bcfadf0cfe45f9a7a6c1db5dca08d9a/packages/react-select/src/Select.tsx#L1928-L1931) is available when the menu first opens.
   >
@@ -407,7 +407,7 @@ There will be an un-zipped directory named after the `BUILD_TARGET` env (e.g., `
 >
 > * **OS** (e.g., Windows, macOS, Android, etc.)
 > * **Browser** (e.g., Chrome, Firefox, etc.)
-> * **Showdex Version** (e.g., v1.1.3)
+> * **Showdex Version** (e.g., v1.1.4)
 > * **Format**, if applicable (e.g., Gen 9 National Dex AG)
 >
 > If you would like to be [credited for your contribution](#contributors), please also include your username on [**Smogon Forums**](https://smogon.com/forums). Otherwise, your **GitHub** username will be used, unless you don't want to be credited.
@@ -495,6 +495,7 @@ big <strong>･ﾟ✧&nbsp;&nbsp;sparkly thank&nbsp;&nbsp;✧ﾟ･</strong> to 
     </tr>
     <tr>
       <td width="205px" align="center">&nbsp;･ﾟ✧&nbsp;&nbsp;<strong>Nate M</strong>&nbsp;&nbsp;✧ﾟ･&nbsp;</td>
+      <td width="205px" align="center">&nbsp;･ﾟ✧&nbsp;&nbsp;<strong>Tanuj C</strong>&nbsp;&nbsp;✧ﾟ･&nbsp;</td>
     </tr>
   </tbody>
 </table>
@@ -551,6 +552,7 @@ another big thank to these fine people for helping with development!
       <td width="220px" align="center"><a href="https://smogon.com/forums/members/iodyne.567157"><strong>Iodyne</strong></a></td>
     </tr>
     <tr>
+      <td width="220px" align="center"><a href="https://smogon.com/forums/members/itr.589896"><strong>ITR</strong></a></td>
       <td width="220px" align="center"><a href="https://smogon.com/forums/members/ketchuppainting.610401"><strong>ketchuppainting</strong></a></td>
       <td width="220px" align="center"><a href="https://smogon.com/forums/members/kibo.552274"><strong>Kibo</strong></a></td>
       <td width="220px" align="center"><a href="https://smogon.com/forums/members/kirigon.349282"><strong>Kirigon</strong></a></td>
@@ -563,38 +565,42 @@ another big thank to these fine people for helping with development!
       <td width="220px" align="center"><a href="https://smogon.com/forums/members/machjacob.555741"><strong>MachJacob</strong></a></td>
     </tr>
     <tr>
+      <td width="220px" align="center"><a href="https://smogon.com/forums/members/mandibuladel5555.564701"><strong>Mandibuladel5555</strong></td>
       <td width="220px" align="center"><a href="https://smogon.com/forums/members/maxouille.390049"><strong>Maxouille</strong></a> · <a href="https://github.com/Maxouille64">GitHub</a></td>
       <td width="220px" align="center"><a href="https://reddit.com/r/pokemonshowdown/comments/x5bi27/showdex_an_autoupdating_damage_calculator_built/in0zpcd"><strong>mdragon13</strong></a></td>
       <td width="220px" align="center"><a href="https://smogon.com/forums/members/mia.425427"><strong>Mia</strong></a> · <a href="https://github.com/mia-pi-git">GitHub</a></td>
-      <td width="220px" align="center"><a href="https://github.com/mpique"><strong>mpique</strong></a></td>
     </tr>
     <tr>
+      <td width="220px" align="center"><a href="https://github.com/mpique"><strong>mpique</strong></a></td>
       <td width="220px" align="center"><a href="https://github.com/mnittsch"><strong>mnittsch</strong></a></td>
       <td width="220px" align="center"><a href="https://smogon.com/forums/members/nails.51373"><strong>Nails</strong></a></td>
       <td width="220px" align="center"><a href="https://smogon.com/forums/members/orangelego21.315566"><strong>orangelego21</strong></a></td>
-      <td width="220px" align="center"><a href="https://smogon.com/forums/members/paolode99.568718"><strong>paolode99</strong></a></td>
     </tr>
     <tr>
+      <td width="220px" align="center"><a href="https://smogon.com/forums/members/paolode99.568718"><strong>paolode99</strong></a></td>
+      <td width="220px" align="center"><a href="https://smogon.com/forums/members/pokeblade101.254632"><strong>pokeblade101</strong></a></td>
       <td width="220px" align="center"><a href="https://smogon.com/forums/members/runoisch.568189"><strong>Runoisch</strong></a></td>
       <td width="220px" align="center"><a href="https://smogon.com/forums/members/ry4242.551466"><strong>ry4242</strong></a></td>
+    </tr>
+    <tr>
       <td width="220px" align="center"><a href="https://smogon.com/forums/members/sabelette.583793"><strong>Sabelette</strong></td>
       <td width="220px" align="center"><a href="https://smogon.com/forums/members/shiox.495116"><strong>Shiox</strong></a></td>
-    </tr>
-    <tr>
       <td width="220px" align="center"><a href="https://smogon.com/forums/members/shock3600.312963"><strong>Shock3600</strong></a> · <a href="https://github.com/Shock3600">GitHub</a></td>
       <td width="220px" align="center"><a href="https://smogon.com/forums/members/sh0shin.557719"><strong>sh0shin</strong></a>
+    </tr>
+    <tr>
       <td width="220px" align="center"><a href="https://smogon.com/forums/members/singiamtel.382208"><strong>Singiamtel</strong></a> · <a href="https://github.com/singiamtel">GitHub</a></td>
       <td width="220px" align="center"><a href="https://smogon.com/forums/members/surgent-james.483985"><strong>Surgent James</strong></a></td>
-    </tr>
-    <tr>
       <td width="220px" align="center"><a href="https://github.com/TheDebatingOne"><strong>TheDebatingOne</strong></a></td>
       <td width="220px" align="center"><a href="https://smogon.com/forums/members/throhking.94778"><strong>ThrohKing</strong></a></td>
-      <td width="220px" align="center"><a href="https://smogon.com/forums/members/tj.331538"><strong>TJ</strong></a></td>
-      <td width="220px" align="center"><a href="https://smogon.com/forums/members/timboberino.619145"><strong>Timboberino</strong></a></td>
     </tr>
     <tr>
+      <td width="220px" align="center"><a href="https://smogon.com/forums/members/tj.331538"><strong>TJ</strong></a></td>
+      <td width="220px" align="center"><a href="https://smogon.com/forums/members/timboberino.619145"><strong>Timboberino</strong></a></td>
       <td width="220px" align="center"><a href="https://smogon.com/forums/members/trainerx493.121411"><strong>TrainerX493</strong></a></td>
       <td width="220px" align="center"><a href="https://github.com/zooki2006"><strong>zooki2006</strong></a></td>
+    </tr>
+    <tr>
       <td width="220px" align="center"><a href="https://smogon.com/forums/members/zuils.596051"><strong>zuils</strong></a> · <a href="https://github.com/zuils">GitHub</a></td>
     </tr>
   </tbody>

--- a/README.md
+++ b/README.md
@@ -556,51 +556,51 @@ another big thank to these fine people for helping with development!
       <td width="220px" align="center"><a href="https://smogon.com/forums/members/ketchuppainting.610401"><strong>ketchuppainting</strong></a></td>
       <td width="220px" align="center"><a href="https://smogon.com/forums/members/kibo.552274"><strong>Kibo</strong></a></td>
       <td width="220px" align="center"><a href="https://smogon.com/forums/members/kirigon.349282"><strong>Kirigon</strong></a></td>
-      <td width="220px" align="center"><a href="https://reddit.com/r/pokemonshowdown/comments/x5bi27/showdex_an_autoupdating_damage_calculator_built/in7624p"><strong>kirito_1707</strong></a></td>
     </tr>
     <tr>
+      <td width="220px" align="center"><a href="https://reddit.com/r/pokemonshowdown/comments/x5bi27/showdex_an_autoupdating_damage_calculator_built/in7624p"><strong>kirito_1707</strong></a></td>
       <td width="220px" align="center"><a href="https://twitch.tv/lazosful"><strong>Lazosful</strong></a></td>
       <td width="220px" align="center"><a href="https://github.com/Legend-Recalls"><strong>Legend-Recalls</strong></a></td>
       <td width="220px" align="center"><a href="https://smogon.com/forums/members/lighthouse64.322009"><strong>lighthouse64</strong></a></td>
-      <td width="220px" align="center"><a href="https://smogon.com/forums/members/machjacob.555741"><strong>MachJacob</strong></a></td>
     </tr>
     <tr>
+      <td width="220px" align="center"><a href="https://smogon.com/forums/members/machjacob.555741"><strong>MachJacob</strong></a></td>
       <td width="220px" align="center"><a href="https://smogon.com/forums/members/mandibuladel5555.564701"><strong>Mandibuladel5555</strong></td>
       <td width="220px" align="center"><a href="https://smogon.com/forums/members/maxouille.390049"><strong>Maxouille</strong></a> · <a href="https://github.com/Maxouille64">GitHub</a></td>
       <td width="220px" align="center"><a href="https://reddit.com/r/pokemonshowdown/comments/x5bi27/showdex_an_autoupdating_damage_calculator_built/in0zpcd"><strong>mdragon13</strong></a></td>
-      <td width="220px" align="center"><a href="https://smogon.com/forums/members/mia.425427"><strong>Mia</strong></a> · <a href="https://github.com/mia-pi-git">GitHub</a></td>
     </tr>
     <tr>
+      <td width="220px" align="center"><a href="https://smogon.com/forums/members/mia.425427"><strong>Mia</strong></a> · <a href="https://github.com/mia-pi-git">GitHub</a></td>
       <td width="220px" align="center"><a href="https://github.com/mpique"><strong>mpique</strong></a></td>
       <td width="220px" align="center"><a href="https://github.com/mnittsch"><strong>mnittsch</strong></a></td>
       <td width="220px" align="center"><a href="https://smogon.com/forums/members/nails.51373"><strong>Nails</strong></a></td>
-      <td width="220px" align="center"><a href="https://smogon.com/forums/members/orangelego21.315566"><strong>orangelego21</strong></a></td>
     </tr>
     <tr>
+      <td width="220px" align="center"><a href="https://smogon.com/forums/members/orangelego21.315566"><strong>orangelego21</strong></a></td>
       <td width="220px" align="center"><a href="https://smogon.com/forums/members/paolode99.568718"><strong>paolode99</strong></a></td>
       <td width="220px" align="center"><a href="https://smogon.com/forums/members/pokeblade101.254632"><strong>pokeblade101</strong></a></td>
       <td width="220px" align="center"><a href="https://smogon.com/forums/members/runoisch.568189"><strong>Runoisch</strong></a></td>
-      <td width="220px" align="center"><a href="https://smogon.com/forums/members/ry4242.551466"><strong>ry4242</strong></a></td>
     </tr>
     <tr>
+      <td width="220px" align="center"><a href="https://smogon.com/forums/members/ry4242.551466"><strong>ry4242</strong></a></td>
       <td width="220px" align="center"><a href="https://smogon.com/forums/members/sabelette.583793"><strong>Sabelette</strong></td>
       <td width="220px" align="center"><a href="https://smogon.com/forums/members/shiox.495116"><strong>Shiox</strong></a></td>
       <td width="220px" align="center"><a href="https://smogon.com/forums/members/shock3600.312963"><strong>Shock3600</strong></a> · <a href="https://github.com/Shock3600">GitHub</a></td>
-      <td width="220px" align="center"><a href="https://smogon.com/forums/members/sh0shin.557719"><strong>sh0shin</strong></a>
     </tr>
     <tr>
+      <td width="220px" align="center"><a href="https://smogon.com/forums/members/sh0shin.557719"><strong>sh0shin</strong></a>
       <td width="220px" align="center"><a href="https://smogon.com/forums/members/singiamtel.382208"><strong>Singiamtel</strong></a> · <a href="https://github.com/singiamtel">GitHub</a></td>
       <td width="220px" align="center"><a href="https://smogon.com/forums/members/surgent-james.483985"><strong>Surgent James</strong></a></td>
       <td width="220px" align="center"><a href="https://github.com/TheDebatingOne"><strong>TheDebatingOne</strong></a></td>
-      <td width="220px" align="center"><a href="https://smogon.com/forums/members/throhking.94778"><strong>ThrohKing</strong></a></td>
     </tr>
     <tr>
+      <td width="220px" align="center"><a href="https://smogon.com/forums/members/throhking.94778"><strong>ThrohKing</strong></a></td>
       <td width="220px" align="center"><a href="https://smogon.com/forums/members/tj.331538"><strong>TJ</strong></a></td>
       <td width="220px" align="center"><a href="https://smogon.com/forums/members/timboberino.619145"><strong>Timboberino</strong></a></td>
       <td width="220px" align="center"><a href="https://smogon.com/forums/members/trainerx493.121411"><strong>TrainerX493</strong></a></td>
-      <td width="220px" align="center"><a href="https://github.com/zooki2006"><strong>zooki2006</strong></a></td>
     </tr>
     <tr>
+      <td width="220px" align="center"><a href="https://github.com/zooki2006"><strong>zooki2006</strong></a></td>
       <td width="220px" align="center"><a href="https://smogon.com/forums/members/zuils.596051"><strong>zuils</strong></a> · <a href="https://github.com/zuils">GitHub</a></td>
     </tr>
   </tbody>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "showdex",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Pokémon Showdown extension that harnesses the power of parabolic calculus to strategically extract your opponents' Elo.",
   "author": "Keith Choison <keith@tize.io>",
   "license": "AGPL-3.0",

--- a/src/consts/app/players.ts
+++ b/src/consts/app/players.ts
@@ -60,7 +60,7 @@ export const ShowdexPlayerTitles: ShowdexPlayerTitle[] = [{
     ['ttoki', 'twitch.tv/tt0ki'],
   ],
 }, {
-  title: 'Showdex Royalty',
+  title: 'Showdex VIP',
   icon: 'crown',
   iconDescription: 'Crown Icon',
 
@@ -70,6 +70,7 @@ export const ShowdexPlayerTitles: ShowdexPlayerTitle[] = [{
   },
 
   userIds: [
+    'agentlag',
     ['finchinator', 'Our Lord and Savior'],
     ['mudkipnerd', "What's a King to a God"],
     ['nails', 'VGC Legend'],

--- a/src/consts/app/supporters.ts
+++ b/src/consts/app/supporters.ts
@@ -28,6 +28,7 @@ export const ShowdexDonorTiers: ShowdexSupporterTier[] = [{
     'Peter T',
     'Connor M',
     'Nate M',
+    'Tanuj C',
   ],
 }];
 

--- a/src/pages/Calcdex/CalcdexProvider.tsx
+++ b/src/pages/Calcdex/CalcdexProvider.tsx
@@ -467,7 +467,11 @@ export const CalcdexProvider = ({
           Showdown.StatName,
           number,
         ]) => {
-          const baseValue = prevPokemon.baseStats?.[stat] ?? -1;
+          const baseValue = (
+            prevPokemon.transformedForme && stat !== 'hp'
+              ? prevPokemon.transformedBaseStats?.[stat]
+              : prevPokemon.baseStats?.[stat]
+          ) ?? -1;
 
           if (baseValue === value) {
             delete payload.dirtyBaseStats[stat];

--- a/src/pages/Calcdex/PokeStats.tsx
+++ b/src/pages/Calcdex/PokeStats.tsx
@@ -219,7 +219,13 @@ export const PokeStats = ({
 
           {statNames.map((stat) => {
             const statLabel = stat.toUpperCase();
-            const baseStat = pokemon?.dirtyBaseStats?.[stat] ?? pokemon?.baseStats?.[stat];
+
+            const baseStat = pokemon?.dirtyBaseStats?.[stat] ?? (
+              pokemon?.transformedForme && stat !== 'hp'
+                ? pokemon.transformedBaseStats
+                : pokemon?.baseStats
+            )?.[stat] as number;
+
             const pristine = typeof pokemon?.dirtyBaseStats?.[stat] !== 'number';
             const disabled = !pokemon?.speciesForme;
 

--- a/src/redux/actions/syncBattle.ts
+++ b/src/redux/actions/syncBattle.ts
@@ -26,7 +26,12 @@ import { calcCalcdexId, calcPokemonCalcdexId } from '@showdex/utils/calc';
 import { env } from '@showdex/utils/core';
 import { logger } from '@showdex/utils/debug';
 import type { GenerationNum } from '@smogon/calc';
-import type { CalcdexBattleState, RootState } from '@showdex/redux/store';
+import type {
+  CalcdexBattleState,
+  CalcdexPlayerKey,
+  CalcdexPokemon,
+  RootState,
+} from '@showdex/redux/store';
 
 export interface SyncBattlePayload {
   battle: Showdown.Battle;
@@ -168,6 +173,14 @@ export const syncBattle = createAsyncThunk<CalcdexBattleState, SyncBattlePayload
       ));
     }
 
+    // keep track of CalcdexPokemon mutations from one player to another
+    // (e.g., revealed properties of the transform target Pokemon from the current player's transformed Pokemon)
+    const futureMutations = AllPlayerKeys.reduce((prev, key) => {
+      prev[key] = [];
+
+      return prev;
+    }, <Record<CalcdexPlayerKey, DeepPartial<CalcdexPokemon>[]>> {});
+
     for (const playerKey of AllPlayerKeys) {
       // l.debug('Processing player', playerKey);
 
@@ -192,6 +205,10 @@ export const syncBattle = createAsyncThunk<CalcdexBattleState, SyncBattlePayload
 
       if (player.rating && playerState.rating !== player.rating) {
         playerState.rating = player.rating;
+      }
+
+      if (!playerState.active) {
+        playerState.active = true;
       }
 
       // l.debug(
@@ -575,6 +592,113 @@ export const syncBattle = createAsyncThunk<CalcdexBattleState, SyncBattlePayload
             } // end shouldApplyPreset
           } // end shouldAddPresets
         } // end battleState.sheets.length
+
+        // detect if Pokemon is transformed and to which player & which Pokemon,
+        // so we can apply those known properties to that Pokemon in that player's state
+        // (note: we'd only know these properties from the server, i.e., the auth user is also a player)
+        if (syncedPokemon.serverSourced && syncedPokemon.transformedForme && clientPokemon?.volatiles?.transform?.length) {
+          // since we sanitized the volatiles earlier, we actually need the pointer to the target pokemon
+          // from the original Showdown.Pokemon (i.e., the clientPokemon) to retrieve its ident
+          const targetClientPokemon = <Showdown.Pokemon> <unknown> clientPokemon.volatiles.transform[1];
+          const targetPlayerKey = (!!targetClientPokemon?.ident && detectPlayerKeyFromPokemon(targetClientPokemon)) || null;
+
+          // update: this isn't fool-proof since the corresponding state of the targetClientPokemon
+          // may not have initialized fully yet! (e.g., we're p1, transformed Pokemon belongs to p2, but p2 isn't init'd yet)
+          // const targetPokemonState = (
+          //   AllPlayerKeys.includes(targetPlayerKey)
+          //     && battleState[targetPlayerKey].pokemon?.find((p) => (
+          //       (!!targetClientPokemon.calcdexId && p?.calcdexId === targetClientPokemon.calcdexId)
+          //         || p?.ident === targetClientPokemon.ident
+          //     ))
+          // ) || null;
+
+          // at this point, we'd know both targetClientPokemon & targetPlayerKey are valid
+          if (AllPlayerKeys.includes(targetPlayerKey)) {
+            l.debug(
+              'Adding revealed info for', targetClientPokemon.ident, 'from transformed', syncedPokemon.ident,
+              '\n', 'targetPlayerKey', targetPlayerKey,
+              '\n', 'targetClientPokemon', targetClientPokemon,
+              // '\n', 'targetPokemonState', targetPokemonState,
+              '\n', 'syncedPokemon', syncedPokemon,
+              '\n', 'battle', battle,
+              '\n', 'battleState', battleState,
+            );
+
+            const mutations: DeepPartial<CalcdexPokemon> = {
+              calcdexId: targetClientPokemon.calcdexId, // may not exist
+              ident: targetClientPokemon.ident, // using this as a fallback
+            };
+
+            if (syncedPokemon.ability) {
+              // targetPokemonState.ability = syncedPokemon.ability;
+              mutations.ability = syncedPokemon.ability;
+
+              l.debug(
+                'Set ability of', targetClientPokemon.ident, 'from transformed', syncedPokemon.ident,
+                '\n', 'ability', syncedPokemon.ability,
+                '\n', 'mutations', mutations,
+                '\n', 'targetClientPokemon', targetClientPokemon,
+                // '\n', 'targetPokemonState', targetPokemonState,
+                '\n', 'syncedPokemon', syncedPokemon,
+              );
+            }
+
+            if (syncedPokemon.transformedMoves.length) {
+              // targetPokemonState.revealedMoves = [...syncedPokemon.transformedMoves];
+              mutations.revealedMoves = [...syncedPokemon.transformedMoves];
+
+              // if (!targetPokemonState.moves?.length) {
+              //   targetPokemonState.moves = [...syncedPokemon.transformedMoves];
+              // }
+
+              l.debug(
+                'Set revealedMoves of', targetClientPokemon.ident, 'from transformed', syncedPokemon.ident,
+                '\n', 'revealedMoves', syncedPokemon.transformedMoves,
+                '\n', 'mutations', mutations,
+                '\n', 'targetClientPokemon', targetClientPokemon,
+                // '\n', 'targetPokemonState', targetPokemonState,
+                '\n', 'syncedPokemon', syncedPokemon,
+              );
+            }
+
+            futureMutations[targetPlayerKey].push(mutations);
+          } // end targetPokemonState?.speciesForme
+        } // end syncedPokemon.serverSourced && syncedPokemon.transformedForme && ...
+
+        // apply any applicable futureMutations
+        const pendingMutations = futureMutations[playerKey]?.filter((m) => (
+          (!!m?.calcdexId && syncedPokemon.calcdexId === m.calcdexId)
+            || (!!m?.ident && syncedPokemon.ident === m.ident)
+        )).map(({
+          // we're removing calcdexId & ident since we know they're for this Pokemon at this point
+          calcdexId, // removed
+          ident, // removed
+          ...mutations
+        }) => ({ ...mutations }));
+
+        if (pendingMutations?.length) {
+          pendingMutations.forEach((mutation) => Object.entries(mutation).forEach(([
+            key,
+            value,
+          ]) => {
+            syncedPokemon[key] = value;
+
+            if (key === 'ability') {
+              syncedPokemon.dirtyAbility = null;
+            }
+
+            if (key === 'revealedMoves') {
+              syncedPokemon.moves = mergeRevealedMoves(syncedPokemon);
+            }
+          }));
+
+          l.debug(
+            'Applied pendingMutations for', syncedPokemon.ident,
+            '\n', 'pendingMutations', pendingMutations,
+            '\n', 'futureMutations', futureMutations,
+            '\n', 'syncedPokemon', syncedPokemon,
+          );
+        }
 
         // extract Gmax/Tera info from the BattleRoom's `request` object, if available
         if (request?.requestType === 'move' && request.side?.id === playerKey) {

--- a/src/redux/actions/syncBattle.ts
+++ b/src/redux/actions/syncBattle.ts
@@ -518,11 +518,14 @@ export const syncBattle = createAsyncThunk<CalcdexBattleState, SyncBattlePayload
 
                 // don't apply the default neutral nature from importPokePaste()
                 // (sets the nature to 'Hardy' by default if a nature couldn't be parsed from the PokePaste)
-                if (PokemonNatures.includes(matchedPreset.nature) && matchedPreset.nature !== 'Hardy') {
+                // update (2023/02/07): allow 'Hardy' natures if we're in Randoms
+                if (PokemonNatures.includes(matchedPreset.nature) && (battleState.format.includes('random') || matchedPreset.nature !== 'Hardy')) {
                   syncedPokemon.nature = matchedPreset.nature;
                 }
 
-                if (Object.keys(matchedPreset.evs || {}).length) {
+                // update (2023/02/07): only apply EVs from the team sheet if the sum of all of them is > 0
+                // (this prevents open team sheets, which doesn't include EVs, from overwriting existing EVs from another preset)
+                if (Object.values(matchedPreset.evs || {}).reduce((sum, value) => sum + (value || 0), 0)) {
                   syncedPokemon.evs = {
                     hp: matchedPreset.evs.hp ?? 0,
                     atk: matchedPreset.evs.atk ?? 0,
@@ -551,7 +554,8 @@ export const syncBattle = createAsyncThunk<CalcdexBattleState, SyncBattlePayload
                 syncedPokemon.moves = mergeRevealedMoves(syncedPokemon);
               }
 
-              if (Object.keys(matchedPreset.ivs || {}).length) {
+              // update (2023/02/07): perform the same treatment for IVs as we did for EVs earlier
+              if (Object.values(matchedPreset.ivs || {}).reduce((sum, value) => sum + (value || 0), 0)) {
                 syncedPokemon.ivs = {
                   hp: matchedPreset.ivs.hp ?? defaultIv,
                   atk: matchedPreset.ivs.atk ?? defaultIv,

--- a/src/utils/battle/syncPokemon.ts
+++ b/src/utils/battle/syncPokemon.ts
@@ -622,7 +622,7 @@ export const syncPokemon = (
   //   && !!transformedAbilities?.length
   //   && (!syncedPokemon.ability || !transformedAbilities.includes(syncedPokemon.dirtyAbility));
 
-  if (dirtyAbility && syncedPokemon.dirtyAbility !== dirtyAbility) {
+  if (!!transformedForme && dirtyAbility && syncedPokemon.dirtyAbility !== dirtyAbility) {
     // [syncedPokemon.dirtyAbility] = transformedAbilities;
     syncedPokemon.dirtyAbility = dirtyAbility;
   }
@@ -652,7 +652,6 @@ export const syncPokemon = (
   } : null;
 
   // if the Pokemon is transformed, auto-set the moves
-  /** @todo make auto-setting transformed moves a toggle? */
   if (syncedPokemon.transformedMoves?.length) {
     if (transformedForme) {
       syncedPokemon.moves = [...syncedPokemon.transformedMoves];

--- a/src/utils/calc/calcPokemonSpreadStats.ts
+++ b/src/utils/calc/calcPokemonSpreadStats.ts
@@ -30,13 +30,12 @@ export const calcPokemonSpreadStats = (
   const legacy = detectLegacyGen(format);
 
   return PokemonStatNames.reduce((prev, stat) => {
-    const baseStat = pokemon.dirtyBaseStats?.[stat] ?? (
-      stat === 'hp'
-        ? pokemon.baseStats?.hp
-        : pokemon.transformedForme
-          ? pokemon.transformedBaseStats?.[stat] ?? pokemon.baseStats?.[stat]
-          : pokemon.baseStats?.[stat]
-    );
+    // update (2023/02/07): cleaned up the baseStat fuckery that existed before
+    const baseStat = pokemon.dirtyBaseStats?.[stat] ?? <number> (
+      pokemon.transformedForme && stat !== 'hp'
+        ? pokemon.transformedBaseStats
+        : pokemon.baseStats
+    )?.[stat];
 
     prev[stat] = calcPokemonStat(
       format,


### PR DESCRIPTION
## Details

This PR adds a hotfix for transformed Pokémon without any sets causing Showdown to become unresponsive. Also adds a couple smaller bug fixes.

See the [v1.1.4 release](https://github.com/doshidak/showdex/releases/tag/v1.1.4) for more detailed information regarding the changes made in this PR.

## Issues

Closes #120  
Closes #121  
Closes #123  