### PR TITLE
Legacy Gen Spreads Hotfix

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -23,7 +23,7 @@ If possible, including the following would be **immensely** helpful!
 * **Device** (e.g., Custom PC, MacBook Pro 14" 2023, eMachines eTower 400i, Samsung Smart Fridge, etc.)
 * **OS** & **Version** (e.g., Windows 11, macOS Sonoma 14.1, Ubuntu 22.04.3 LTS, Android 12, etc.)
 * **Browser** (e.g., Chrome, Firefox, Opera, Netscape Navigator, etc.)
-* **Showdex Version** (e.g., v1.1.8)
+* **Showdex Version** (e.g., v1.1.9)
 * **Format**, if applicable (e.g., Gen 9 VGC 2023 Regulation E Bo3)
 * **Replay**, if applicable
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <table align="center">
   <thead>
     <tr>
-      <th align="center">&nbsp;Current <a href="https://github.com/doshidak/showdex/releases/tag/v1.1.8">v1.1.8</a>&nbsp;</th>
+      <th align="center">&nbsp;Current <a href="https://github.com/doshidak/showdex/releases/tag/v1.1.9">v1.1.9</a>&nbsp;</th>
       <th align="center">&nbsp;Install on <a href="https://chrome.google.com/webstore/detail/dabpnahpcemkfbgfbmegmncjllieilai">Chrome</a> · <a href="https://addons.opera.com/en/extensions/details/showdex">Opera</a> · <a href="https://addons.mozilla.org/en-US/firefox/addon/showdex">Firefox</a> · <a href="https://apps.apple.com/us/app/enhanced-tooltips-for-showdown/id1612964050">Safari</a>&nbsp;</th>
       <th align="center">&nbsp;Discuss on <a href="https://smogon.com/forums/threads/showdex-an-auto-updating-damage-calculator-built-into-showdown.3707265">Smogon</a> · <a href="https://discord.gg/2PXVGGCkm2">Discord</a></th>
     </tr>
@@ -406,7 +406,7 @@ There will be an un-zipped directory named after the `BUILD_TARGET` env (e.g., `
 > * **Device** (e.g., Custom PC, MacBook Pro 14" 2023, eMachines eTower 400i, Samsung Smart Fridge, etc.)
 > * **OS** & **Version** (e.g., Windows 11, macOS Sonoma 14.1, Ubuntu 22.04.3 LTS, Android 12, etc.)
 > * **Browser** (e.g., Chrome, Firefox, Opera, Netscape Navigator, etc.)
-> * **Showdex Version** (e.g., v1.1.8)
+> * **Showdex Version** (e.g., v1.1.9)
 > * **Format**, if applicable (e.g., Gen 9 VGC 2023 Regulation E Bo3)
 > * **Replay**, if applicable
 >

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "showdex",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "Pokémon Showdown extension that harnesses the power of parabolic calculus to strategically extract your opponents' Elo.",
   "author": "Keith Choison <keith@tize.io>",
   "license": "AGPL-3.0",

--- a/src/components/form/Dropdown/Dropdown.tsx
+++ b/src/components/form/Dropdown/Dropdown.tsx
@@ -111,7 +111,7 @@ export const Dropdown = React.forwardRef<SelectInstance, DropdownProps>(({
   scrollMenuIntoView = true,
   captureMenuScroll = false, // do not remove false; Select's default is true
   minMenuHeight = 80,
-  maxMenuHeight = 240,
+  maxMenuHeight = 208,
   tabSelectsValue = true,
   hideSelections,
   autoFocus,

--- a/src/pages/Calcdex/PokeInfo/PokeInfo.tsx
+++ b/src/pages/Calcdex/PokeInfo/PokeInfo.tsx
@@ -790,7 +790,7 @@ export const PokeInfo = ({
               hint={legacy ? 'N/A' : (showPresetSpreads ? (currentSpread || 'Custom') : '???')}
               input={{
                 name: `PokeInfo:${pokemonKey}:${showPresetSpreads ? 'Spreads' : 'Natures'}`,
-                value: showPresetSpreads ? currentSpread : pokemon?.nature,
+                value: legacy ? null : (showPresetSpreads ? currentSpread : pokemon?.nature),
                 onChange: (name: string) => updatePokemon(
                   showPresetSpreads
                     ? hydrateSpread(name, { format })

--- a/src/utils/presets/applyPreset.ts
+++ b/src/utils/presets/applyPreset.ts
@@ -276,14 +276,6 @@ export const applyPreset = (
     if (output.moves.length) {
       output[transformed ? 'transformedMoves' : 'revealedMoves'] = [...output.moves];
     }
-
-    // we probably have an OTS if not complete
-    if (!completePreset) {
-      output.moves = mergeRevealedMoves({
-        ...pokemon,
-        ...output,
-      });
-    }
   }
 
   if (currentForme !== output[formeKey]) {
@@ -309,6 +301,19 @@ export const applyPreset = (
       output.abilities = abilities;
       output.baseStats = baseStats;
     }
+  }
+
+  // we probably have an OTS (Open Team Sheet) if revealing & not complete
+  const shouldMergeMoves = (revealingPreset && !completePreset)
+    || (transformed && !!pokemon.transformedMoves?.length);
+
+  if (shouldMergeMoves) {
+    /**
+     * @todo update this when we support more than 4 moves
+     */
+    output.moves = transformed && pokemon.transformedMoves.length === 4
+      ? [...pokemon.transformedMoves] // preserves the order
+      : mergeRevealedMoves({ ...pokemon, ...output });
   }
 
   // update (2023/10/15): only apply the presetId if we have a complete preset (in case we're applying an OTS preset,


### PR DESCRIPTION
## Details

This PR fixes the Calcdex crashing in legacy gens due to nonexistent Pokémon natures, resulting in reading a nonexistent array's `length`.

That's all folks.