### PR TITLE
Fix calcdex layout for wide phones and tablets

### DIFF
--- a/src/pages/Calcdex/Calcdex.module.scss
+++ b/src/pages/Calcdex/Calcdex.module.scss
@@ -16,7 +16,7 @@
   @include position.absolute($top: 0, $right: 0, $bottom: 0, $left: 640px + 1px);
   z-index: 15;
 
-  @include device.for-mobile {
+  @include device.for-tablet-lg {
     right: 0;
     left: 0;
   }


### PR DESCRIPTION
In tablets and wide phones such as foldable phones the layout of Calcdex is awkward and has a poor usage, see this screenshot:
![image](https://github.com/user-attachments/assets/4a72cf19-569a-42cc-90d3-6b6ec1dccf6c)

This change updates the breakpoint for moving Calcdex to the side so that it only happens when the screen is wide enough to show the battle and Calcdex side by side in a usable way.