### PR TITLE
Support for the Infinite Fusion format on Pokeathlon

### DIFF
--- a/src/components/app/Picon/Picon.tsx
+++ b/src/components/app/Picon/Picon.tsx
@@ -18,7 +18,7 @@ export const Picon = ({
   pokemon,
   facingLeft,
 }: PiconProps): JSX.Element => {
-  const css = Dex?.getPokemonIcon(pokemon || 'pokeball-none', facingLeft).split(';')[0];
+  const css = Dex?.getPokemonIcon(pokemon || 'pokeball-none', facingLeft).split(';').find((s) => s.startsWith('background:'));
   const background = css?.replace(/^background:/, '');
 
   const item = (typeof pokemon !== 'string' && pokemon?.item as ItemName) || null;

--- a/src/components/calc/CalcdexContext/useCalcdexPresets.ts
+++ b/src/components/calc/CalcdexContext/useCalcdexPresets.ts
@@ -560,7 +560,9 @@ export const useCalcdexPresets = (
             pokemon.level = state.defaultLevel;
           }
 
-          pokemon.nature = state.legacy ? 'Hardy' : 'Adamant';
+          // Infinite Fusion randbat sets seem to use Hardy by default
+          const isInfiniteFusion = true;
+          pokemon.nature = state.legacy || isInfiniteFusion ? 'Hardy' : 'Adamant';
           pokemon.ivs = populateStatsTable({}, { spread: 'iv', format: state.format });
           pokemon.evs = populateStatsTable({}, { spread: 'ev', format: state.format });
           pokemon.altTeraTypes = [];

--- a/src/consts/dex/natures.ts
+++ b/src/consts/dex/natures.ts
@@ -7,7 +7,6 @@ export const PokemonNatureBoosts: Record<Showdown.PokemonNature, [up?: Showdown.
   Careful: ['spd', 'spa'],
   Docile: [],
   Gentle: ['spd', 'def'],
-  Hardy: [],
   Hasty: ['spe', 'def'],
   Impish: ['def', 'spa'],
   Jolly: ['spe', 'spa'],
@@ -24,6 +23,7 @@ export const PokemonNatureBoosts: Record<Showdown.PokemonNature, [up?: Showdown.
   Sassy: ['spd', 'spe'],
   Serious: [],
   Timid: ['spe', 'atk'],
+  Hardy: [], // XXX: For some reason, Infinite Fusion will default to the last element in this object
 };
 
 export const PokemonNatures = Object.keys(PokemonNatureBoosts) as Showdown.PokemonNature[];

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -21,7 +21,8 @@
   "permissions": [
     "*://play.pokemonshowdown.com/*",
     "*://*.psim.us/*",
-    "*://play.radicalred.net/*"
+    "*://play.radicalred.net/*",
+    "*://play.pokeathlon.com/*"
   ],
 
   "host_permissions": [

--- a/src/redux/actions/syncPokemon.ts
+++ b/src/redux/actions/syncPokemon.ts
@@ -31,6 +31,7 @@ import {
   hasMegaForme,
 } from '@showdex/utils/dex';
 import { capitalize } from '@showdex/utils/humanize';
+import { getFusionPartNames, getFusedTypes } from '@showdex/utils/battle/infiniteFusion';
 
 // const l = logger('@showdex/redux/actions/syncPokemon()');
 
@@ -372,11 +373,18 @@ export const syncPokemon = (
           syncedPokemon.types = [...changedTypes];
         }
 
+        // Infinite Fusion uses typechange volatiles to set the fused type.
+        const fusionPartNames = getFusionPartNames(syncedPokemon);
+        const isFusedPokemon = !!fusionPartNames;
+        const origTypes = isFusedPokemon
+          ? getFusedTypes(dex.species.get(fusionPartNames.headName), dex.species.get(fusionPartNames.bodyName))
+          : dex.species.get(syncedPokemon.speciesForme)?.types;
+
         // check for type change resets
         const resetTypes = (
           'typechange' in syncedPokemon.volatiles
             && !changedTypes.length
-            && dex.species.get(syncedPokemon.speciesForme)?.types
+            && origTypes
         ) || [];
 
         if (resetTypes?.length) {

--- a/src/utils/battle/infiniteFusion.ts
+++ b/src/utils/battle/infiniteFusion.ts
@@ -4,6 +4,9 @@ export function getFusionPartNames(pokemon: CalcdexPokemon): { headName: string;
   // Find body name by parsing the `details` property.
   // Full text of `details` is something like "Houndoom, L76, F, fusion: Jolteon".
   // Match everything after "fusion: " until end of string or comma.
+  if (!pokemon.details) {
+    return null;
+  }
   const bodyNameMatch = pokemon.details.match(/fusion: (.+?)(?:,|$)/);
   if (!bodyNameMatch || bodyNameMatch.length < 2) {
     return null;

--- a/src/utils/battle/infiniteFusion.ts
+++ b/src/utils/battle/infiniteFusion.ts
@@ -1,0 +1,32 @@
+import { CalcdexPokemon } from '@showdex/interfaces/calc';
+
+export function getFusionPartNames(pokemon: CalcdexPokemon): { headName: string; bodyName: string; } | null {
+  // Find body name by parsing the `details` property.
+  // Full text of `details` is something like "Houndoom, L76, F, fusion: Jolteon".
+  // Match everything after "fusion: " until end of string or comma.
+  const bodyNameMatch = pokemon.details.match(/fusion: (.+?)(?:,|$)/);
+  if (!bodyNameMatch || bodyNameMatch.length < 2) {
+    return null;
+  }
+
+  return {
+    headName: pokemon.speciesForme,
+    bodyName: bodyNameMatch[1],
+  };
+}
+
+export function calculateFusedBaseStats(head: Showdown.Species, body: Showdown.Species): Required<Showdown.StatsTable> {
+  // Formula source: https://infinitefusion.fandom.com/wiki/Fusion_FAQs#Stats
+  const fuseStat = (a: number, b: number) => Math.floor((2 * a) / 3 + b / 3);
+
+  return {
+    // Body primary stats
+    atk: fuseStat(body.baseStats.atk, head.baseStats.atk),
+    def: fuseStat(body.baseStats.def, head.baseStats.def),
+    spe: fuseStat(body.baseStats.spe, head.baseStats.spe),
+    // Head primary stats
+    hp: fuseStat(head.baseStats.hp, body.baseStats.hp),
+    spa: fuseStat(head.baseStats.spa, body.baseStats.spa),
+    spd: fuseStat(head.baseStats.spd, body.baseStats.spd),
+  };
+}

--- a/src/utils/battle/sanitizePokemon.ts
+++ b/src/utils/battle/sanitizePokemon.ts
@@ -17,6 +17,7 @@ import { detectSpeciesForme } from './detectSpeciesForme';
 import { detectToggledAbility } from './detectToggledAbility';
 import { sanitizeMoveTrack } from './sanitizeMoveTrack';
 import { sanitizeVolatiles } from './sanitizeVolatiles';
+import { getFusionPartNames, calculateFusedBaseStats } from './infiniteFusion';
 
 /* eslint-disable @typescript-eslint/indent */
 
@@ -235,8 +236,17 @@ export const sanitizePokemon = <
   // gen is important here; e.g., Crustle, who has 95 base ATK in Gen 5, but 105 in Gen 8
   const species = dex.species.get(sanitizedPokemon.speciesForme);
 
-  // don't really care if species is falsy here
-  sanitizedPokemon.baseStats = { ...species?.baseStats };
+  // If pokemon is a fusion then calculate fused base stats otherwise use normal base stats
+  const fusionPartNames = getFusionPartNames(sanitizedPokemon);
+  const isFusedPokemon = !!fusionPartNames;
+  if (isFusedPokemon) {
+    const fusedBaseStats = calculateFusedBaseStats(dex.species.get(fusionPartNames.headName), dex.species.get(fusionPartNames.bodyName));
+    sanitizedPokemon.baseStats = { ...fusedBaseStats };
+  } else {
+    // don't really care if species is falsy here
+    sanitizedPokemon.baseStats = { ...species?.baseStats };
+  }
+
   sanitizedPokemon.dmaxable = !species?.cannotDynamax;
 
   // grab the base species forme to obtain its other formes

--- a/src/utils/battle/sanitizePokemon.ts
+++ b/src/utils/battle/sanitizePokemon.ts
@@ -17,7 +17,7 @@ import { detectSpeciesForme } from './detectSpeciesForme';
 import { detectToggledAbility } from './detectToggledAbility';
 import { sanitizeMoveTrack } from './sanitizeMoveTrack';
 import { sanitizeVolatiles } from './sanitizeVolatiles';
-import { getFusionPartNames, calculateFusedBaseStats } from './infiniteFusion';
+import { getFusionPartNames, calculateFusedBaseStats, getFusedTypes } from './infiniteFusion';
 
 /* eslint-disable @typescript-eslint/indent */
 
@@ -364,7 +364,9 @@ export const sanitizePokemon = <
   // (checking against typeChanged since if true, should've been already updated above)
   const speciesTypes = (transformedSpecies || species)?.types;
 
-  if (!typeChanged && speciesTypes?.length) {
+  if (isFusedPokemon) {
+    sanitizedPokemon.types = getFusedTypes(dex.species.get(fusionPartNames.headName), dex.species.get(fusionPartNames.bodyName));
+  } else if (!typeChanged && speciesTypes?.length) {
     sanitizedPokemon.types = [...speciesTypes];
   }
 


### PR DESCRIPTION
This patch adds support for the Infinite Fusion format that is being hosted on https://play.pokeathlon.com/. In this format there are lots of new pokemon that are fusions of two existing pokemon, one is the "head" and the other is the "body". Fused pokemon derive their stats, types, move pools, and abilities from their component pokemon.

The amount of code changes is fairly small. I've added functions that calculate the base stats and types of a fusion and applied them to places where the base stats and types are saved to the pokemon (namely in sanitizePokemon and syncPokemon). Everything else seems to just kind of work without needing to change anything.

Things that are missing:
* Something that shows what the body component of a fusion is. Currently it shows the pokemon as just the head component. However, this isn't actually very important information.
* Presets. Tbh I don't know how this works.
* Pokeathlon also hosts a bunch of other weird formats. This patch doesn't do anything to support them.

I'm also in the discord if you'd like to discuss things there.