### PR TITLE
Fix: Honkdex instances for older gens open as blank Gen 9 instances

### DIFF
--- a/src/pages/Honkdex/HonkdexBootstrappable.ts
+++ b/src/pages/Honkdex/HonkdexBootstrappable.ts
@@ -43,27 +43,22 @@ export const MixinHonkdexBootstrappable = <
 
     public constructor(
       instanceId = uuidv4(),
-      gen = defaultGen,
-      format = defaultFormat,
+      gen,
+      format,
     ) {
       super();
 
       this.instanceId = instanceId;
 
       // Check if state exists for this ID
-      const existingState = this.calcdexState;
+      const state = this.calcdexState;
 
-      // If saved data exists, respect its generation. Otherwise, use the default.
-      if (existingState) {
-        this.gen = existingState.gen;
-        this.format = existingState.format;
-      } else {
-        this.gen = gen;
-        this.format = getGenfulFormat(gen, format);
-      }
+      // Prioritize passed values, then state values. Otherwise, use the default.
+      this.gen = gen ?? state.gen ?? defaultGen;
+      const targetFormat = format ?? state.format ?? defaultFormat;
+      this.format = getGenfulFormat(this.gen, targetFormat);
 
       // Now perform the sanity check
-
       if (this.calcdexState?.battleId && this.calcdexState.gen !== this.gen) {
         this.instanceId = uuidv4();
       }


### PR DESCRIPTION
The Bug:
( Fixes #233, #241 (duplicate))
When opening a saved Honkdex instance (e.g., Gen 3), the constructor in HonkdexBootstrappable.ts was initializing with the default generation (Gen 9) before checking the saved state.

This triggered the safety check if (this.calcdexState.gen !== this.gen), causing the app to treat the mismatch as invalid and generating a new random UUID (blank instance) instead of loading the saved data.

The Fix:
Updated the constructor to check if calcdexState exists for the provided instanceId. If it does, use the saved gen and format instead of the defaults. 

Apologies if this misunderstands the architecture, I'm not very experienced with react. In particular, this fix ignores why this.gen is defaulting to gen 9 every time, but ¯\\\_(ツ)\_/¯.