### PR TITLE
Implement Tar Shot modifier in damage calc

### DIFF
--- a/src/interfaces/calc/CalcdexPokemon.ts
+++ b/src/interfaces/calc/CalcdexPokemon.ts
@@ -860,6 +860,13 @@ export interface CalcdexPokemon extends CalcdexLeanPokemon {
   criticalHit?: boolean;
 
   /**
+   * Volatile status conditions Pokemon has.
+   *
+   * * Currently only useful for Tar Shot damage calculation, but could be useful for other moves like it in the future, too.
+   */
+  volatileStatus?: Showdown.PokemonVolatile;
+
+  /**
    * User-modified non-volatile status condition.
    *
    * * In order to allow the user to *forcibly* specify **no** status (aka. "Healthy") when the Pokemon actually has one,

--- a/src/utils/calc/calcMoveBasePower.ts
+++ b/src/utils/calc/calcMoveBasePower.ts
@@ -242,6 +242,10 @@ export const calcMoveBasePower = (
     basePowerMods.push(2);
   }
 
+  if ('tarshot' in opponentPokemon?.volatiles && moveType === 'Fire') {
+    basePowerMods.push(2);
+  }
+
   if (basePowerMods.length) {
     basePower = basePowerMods.reduce((bp, mod) => Math.floor(bp * clamp(0, mod)), basePower);
   }


### PR DESCRIPTION
Implements the damage modifier from Coalossal's signature move, Tar Shot; 2x damage from fire moves on target afflicted by it.

-- passionfruit_fan on showdown :)