### PR TITLE
Fix: B12P6 format presets not loading

### DIFF
--- a/src/redux/factories/buildPresetQuery.ts
+++ b/src/redux/factories/buildPresetQuery.ts
@@ -77,6 +77,10 @@ const FormatReplacements: [test: RegExp, replace: RegExp, replacement: string][]
   // Randomized Format Spotlight as of 2024/01/10
   // e.g., 'gen6firstbloodrandombattle' -> 'gen6randombattle'
   [/firstblood/i, null, ''],
+  
+  // Random Battle Shared Power B12P6
+  // e.g., 'gen9randombattlesharedpowerb12p6' -> 'gen9randombattle'
+  [/randombattlesharedpowerb12p6/i, /randombattlesharedpowerb12p6/i, 'randombattle'],
 ];
 
 // 10/10 function name


### PR DESCRIPTION
The Bug:
The 'gen9randombattlesharedpowerb12p6' format had no mapping in the FormatReplacements array, causing the system to search for a non-existent preset endpoint instead of using standard random battle presets.

The Fix:
Added regex mapping to transform 'gen9randombattlesharedpowerb12p6' into 'gen9randombattle', enabling correct preset fetching for B12P6 battles.