### PR TITLE
Declare missing lexical package dependencies for pnpm:build~

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,12 @@
     "@dnd-kit/modifiers": "^7.0.0",
     "@dnd-kit/sortable": "^8.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@lexical/code": "^0.42.0",
+    "@lexical/link": "^0.42.0",
+    "@lexical/list": "^0.42.0",
+    "@lexical/markdown": "^0.42.0",
     "@lexical/react": "^0.42.0",
+    "@lexical/rich-text": "^0.42.0",
     "@react-hook/size": "^2.1.2",
     "@react-spring/web": "^10.0.3",
     "@reduxjs/toolkit": "^2.11.2",
@@ -170,7 +175,9 @@
   },
   "pnpm": {
     "onlyBuiltDependencies": [
-      "@swc/core"
+      "@parcel/watcher",
+      "@swc/core",
+      "ghooks"
     ],
     "overrides": {
       "webpack-visualizer-plugin2>react": "$react",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,9 +32,24 @@ importers:
       '@dnd-kit/utilities':
         specifier: ^3.2.2
         version: 3.2.2(react@19.2.4)
+      '@lexical/code':
+        specifier: ^0.42.0
+        version: 0.42.0
+      '@lexical/link':
+        specifier: ^0.42.0
+        version: 0.42.0
+      '@lexical/list':
+        specifier: ^0.42.0
+        version: 0.42.0
+      '@lexical/markdown':
+        specifier: ^0.42.0
+        version: 0.42.0
       '@lexical/react':
         specifier: ^0.42.0
         version: 0.42.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(yjs@13.6.30)
+      '@lexical/rich-text':
+        specifier: ^0.42.0
+        version: 0.42.0
       '@react-hook/size':
         specifier: ^2.1.2
         version: 2.1.2(react@19.2.4)
@@ -672,6 +687,12 @@ packages:
 
   '@lexical/code-core@0.42.0':
     resolution: {integrity: sha512-vrZTUPWDJkHjAAvuV2+Qte4vYE80s7hIO7wxipiJmWojGx6lcmQjO+UqJ8AIrqI4Wjy8kXrK74kisApWmwxuCw==}
+
+  '@lexical/code-prism@0.42.0':
+    resolution: {integrity: sha512-KgngkUtgcgC8ocBnfGyN71CC3EnP5PMFAmH1KcGp/+jSgl11nRpCjwYYIoUHm6AB7jKJ8dLbd/UUmShARjUnGA==}
+
+  '@lexical/code@0.42.0':
+    resolution: {integrity: sha512-KMu1nWae9pHvA9nl6dlJacbt3QBBNemgalmLJcZ5QhdGEQA1cVIU4gBPJ5TJqgY9XF7WZgj5JvDIPxjrZmf+XQ==}
 
   '@lexical/devtools-core@0.42.0':
     resolution: {integrity: sha512-8nP8eE9i8JImgSrvInkWFfMCmXVKp3w3VaOvbJysdlK/Zal6xd8EWJEi6elj0mUW5T/oycfipPs2Sfl7Z+n14A==}
@@ -4482,6 +4503,18 @@ snapshots:
 
   '@lexical/code-core@0.42.0':
     dependencies:
+      lexical: 0.42.0
+
+  '@lexical/code-prism@0.42.0':
+    dependencies:
+      '@lexical/code-core': 0.42.0
+      lexical: 0.42.0
+      prismjs: 1.30.0
+
+  '@lexical/code@0.42.0':
+    dependencies:
+      '@lexical/code-core': 0.42.0
+      '@lexical/code-prism': 0.42.0
       lexical: 0.42.0
 
   '@lexical/devtools-core@0.42.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':


### PR DESCRIPTION
### **Issue**
`scripts/build.js:24-31` only checks the top-level err argument from webpack and ignores the stats object. 

Compilation errors leave err === null, so the script always prints "Build for ... successful!" and exits 0 even when nothing emits to disk and no .xpi is produced.

_This bug is also fixable but I have an issue with making pull requests on foreign build.js files lol. 
pnpm doesn't hoist undeclared deps to the resolvable path, so webpack can't find them._   

If you want me to commit the fix to build.js just let me know on this pr. 