### PR TITLE
fix for hackmons not guessable spreads

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,12 @@
     "@dnd-kit/modifiers": "^7.0.0",
     "@dnd-kit/sortable": "^8.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@lexical/code": "^0.44.0",
+    "@lexical/link": "^0.44.0",
+    "@lexical/list": "^0.44.0",
+    "@lexical/markdown": "^0.44.0",
     "@lexical/react": "^0.42.0",
+    "@lexical/rich-text": "^0.44.0",
     "@react-hook/size": "^2.1.2",
     "@react-spring/web": "^10.0.3",
     "@reduxjs/toolkit": "^2.11.2",
@@ -116,6 +121,7 @@
     "uuid": "^13.0.0"
   },
   "devDependencies": {
+    "@eslint/eslintrc": "^3.3.5",
     "@eslint/js": "^10.0.1",
     "@swc/core": "^1.15.21",
     "@types/base-64": "^1.0.0",
@@ -149,6 +155,7 @@
     "file-loader": "^6.2.0",
     "ghooks": "^2.0.4",
     "glob": "^13.0.6",
+    "globals": "^17.6.0",
     "html-loader": "^5.1.0",
     "html-webpack-plugin": "^5.5.3",
     "postcss": "^8.4.26",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,9 +32,24 @@ importers:
       '@dnd-kit/utilities':
         specifier: ^3.2.2
         version: 3.2.2(react@19.2.4)
+      '@lexical/code':
+        specifier: ^0.44.0
+        version: 0.44.0
+      '@lexical/link':
+        specifier: ^0.44.0
+        version: 0.44.0
+      '@lexical/list':
+        specifier: ^0.44.0
+        version: 0.44.0
+      '@lexical/markdown':
+        specifier: ^0.44.0
+        version: 0.44.0
       '@lexical/react':
         specifier: ^0.42.0
         version: 0.42.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(yjs@13.6.30)
+      '@lexical/rich-text':
+        specifier: ^0.44.0
+        version: 0.44.0
       '@react-hook/size':
         specifier: ^2.1.2
         version: 2.1.2(react@19.2.4)
@@ -144,6 +159,9 @@ importers:
         specifier: ^13.0.0
         version: 13.0.0
     devDependencies:
+      '@eslint/eslintrc':
+        specifier: ^3.3.5
+        version: 3.3.5
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.1.0(jiti@2.6.1))
@@ -243,6 +261,9 @@ importers:
       glob:
         specifier: ^13.0.6
         version: 13.0.6
+      globals:
+        specifier: ^17.6.0
+        version: 17.6.0
       html-loader:
         specifier: ^5.1.0
         version: 5.1.0(webpack@5.105.4(@swc/core@1.15.21(@swc/helpers@0.5.20)))
@@ -468,6 +489,10 @@ packages:
     resolution: {integrity: sha512-QUPblTtE51/7/Zhfv8BDwO0qkkzQL7P/aWWbqcf4xWLEYn1oKjdO0gglQBB4GAsu7u6wjijbCmzsUTy6mnk6oQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
+  '@eslint/eslintrc@3.3.5':
+    resolution: {integrity: sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@eslint/js@10.0.1':
     resolution: {integrity: sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
@@ -670,8 +695,20 @@ packages:
   '@lexical/clipboard@0.42.0':
     resolution: {integrity: sha512-D3K2ID0zew/+CKpwxnUTTh/N46yU4IK8bFWV9Htz+g1vFhgUF9UnDOQCmqpJbdP7z+9U1F8rk3fzf9OmP2Fm2w==}
 
+  '@lexical/clipboard@0.44.0':
+    resolution: {integrity: sha512-nfmNIs7uENqlDI7cm2E4I1Yp8mDJGMhEQIrIV2rNWnL1oeHVXQ7yuYdyoPdcY1zuj/9nvkYBQYUEh0QiGwpETA==}
+
   '@lexical/code-core@0.42.0':
     resolution: {integrity: sha512-vrZTUPWDJkHjAAvuV2+Qte4vYE80s7hIO7wxipiJmWojGx6lcmQjO+UqJ8AIrqI4Wjy8kXrK74kisApWmwxuCw==}
+
+  '@lexical/code-core@0.44.0':
+    resolution: {integrity: sha512-m57JyXTIvW1tsqw/Vuogk8jqWCZZIeFQbWybRc46ytR8ReDgzPRODpN8+dacIIeRH5yC5UC3lAa743mtdNkxqg==}
+
+  '@lexical/code-prism@0.44.0':
+    resolution: {integrity: sha512-E8hmosuviwDfZqNyFKf2Vym8lV4shRFRHsRgYHzA3UCp88OqsxcSpyIwZk276khvJ2Zd4DupqJht/h+djezO4Q==}
+
+  '@lexical/code@0.44.0':
+    resolution: {integrity: sha512-d2rZUlGC8noGn/XbVrPyPZ86gYKT5a1DdsCSYIWnw/aqAs9G0xaIBcV9ABH+9cUS9fY5GDHaKTllHKIA8VRAxQ==}
 
   '@lexical/devtools-core@0.42.0':
     resolution: {integrity: sha512-8nP8eE9i8JImgSrvInkWFfMCmXVKp3w3VaOvbJysdlK/Zal6xd8EWJEi6elj0mUW5T/oycfipPs2Sfl7Z+n14A==}
@@ -682,8 +719,14 @@ packages:
   '@lexical/dragon@0.42.0':
     resolution: {integrity: sha512-/TQzP+7PLJMqq9+MlgQWiJsxS9GOOa8Gp0svCD8vNIOciYmXfd28TR1Go+ZnBWwr7k/2W++3XUYVQU2KUcQsDQ==}
 
+  '@lexical/dragon@0.44.0':
+    resolution: {integrity: sha512-RhlsjVDket9k1+YFEkDE0/7Qyrh2BI0vxBMzrWwPJTXX/4YFanYN9su8RSabkIukBBJ3QiNOOoC8FKK4Lkr4qg==}
+
   '@lexical/extension@0.42.0':
     resolution: {integrity: sha512-rkZq/h8d1BenKRqU4t/zQUVfY/RinMX1Tz7t+Ee3ss0sk+kzP4W+URXNAxpn7r39Vn6wrFBqmCziah3dLAIqPw==}
+
+  '@lexical/extension@0.44.0':
+    resolution: {integrity: sha512-BsYtoc+0EU0pqcOpf/lIUDU6LQVO6zX2AawZoUWJzT3Wzfov23qsqZWvl2WGM9dnRTN5iISJL3Fl53bQVxiXxw==}
 
   '@lexical/hashtag@0.42.0':
     resolution: {integrity: sha512-WOg5nFOfhabNBXzEIutdWDj+TUHtJEezj6w8jyYDGqZ31gu0cgrXSeV8UIynz/1oj+rpzEeEB7P6ODnwgjt7qA==}
@@ -694,17 +737,29 @@ packages:
   '@lexical/html@0.42.0':
     resolution: {integrity: sha512-KgBUDLXehufCsXW3w0XsuoI2xecIhouOishnaNOH4zIA7dAtnNAfdPN/kWrWs0s83gz44OrnqccP+Bprw3UDEQ==}
 
+  '@lexical/html@0.44.0':
+    resolution: {integrity: sha512-5X6eGsgwtqPxABsuShUxF7ZfyB/U4GwSEyeonvwH1Vc/5Q2uQVjlB+FAYd+MNwWMHMh4d4+yZ3l70AtIuhr5eg==}
+
   '@lexical/link@0.42.0':
     resolution: {integrity: sha512-cdeM/+f+kn7aGwW/3FIi6USjl1gBNdEEwg0/ZS+KlYcsy8gxx2e4cyVjsomBu/WU17Qxa0NC0paSr7qEJ/1Fig==}
 
+  '@lexical/link@0.44.0':
+    resolution: {integrity: sha512-uvEqEol/mLEzGVQd8Rok9I48RgYPKokM/nsclI9nYcEdccVOM2Nri4ntoRwodhbccFLtjMPl8OBldwXbfc77tQ==}
+
   '@lexical/list@0.42.0':
     resolution: {integrity: sha512-TIezILnmIVuvfqEEbcMnsT4xQRlswI6ysHISqsvKL6l5EBhs1gqmNYjHa/Yrfzaq5y52TM1PAtxbFts+G7N6kg==}
+
+  '@lexical/list@0.44.0':
+    resolution: {integrity: sha512-ZTCWxDz1okPrC9FBXi1yV3W5fbQQeMUlFIcSVF9HibcVPmCsPa900IxthuiQbGiTycUyXDTOB3IUYRtlJNtpjw==}
 
   '@lexical/mark@0.42.0':
     resolution: {integrity: sha512-H1aGjbMEcL4B8GT7bm/ePHm7j3Wema+wIRNPmxMtXGMz5gpVN3gZlvg2UcUHHJb00SrBA95OUVT5I2nu/KP06w==}
 
   '@lexical/markdown@0.42.0':
     resolution: {integrity: sha512-+mOxgBiumlgVX8Acna+9HjJfSOw1jywufGcAQq3/8S11wZ4gE0u13AaR8LMmU8ydVeOQg09y8PNzGNQ/avZJbg==}
+
+  '@lexical/markdown@0.44.0':
+    resolution: {integrity: sha512-DwlXdp85pYMo3exDF6W3iz8plpuP+RQ4Me4Iljm7O5aPDp0SSrIoZxyX4zS668mVAoz5HHj1Ka0kQkft8mq26Q==}
 
   '@lexical/offset@0.42.0':
     resolution: {integrity: sha512-V+4af1KmTOnBZrR+kU3e6eD33W/g3QqMPPp3cpFwyXk/dKRc4K8HfyDsSDrjop1mPd9pl3lKSiEmX6uQG8K9XQ==}
@@ -724,8 +779,14 @@ packages:
   '@lexical/rich-text@0.42.0':
     resolution: {integrity: sha512-v4YgiM3oK3FZcRrfB+LetvLbQ5aee9MRO9tHf0EFweXg19XnSjHV0cfPAW7TyPxRELzB69+K0Q3AybRlTMjG4Q==}
 
+  '@lexical/rich-text@0.44.0':
+    resolution: {integrity: sha512-IIdrutK5GY47ITjPlZB7KzUi9dBDwygsyFOwolnrYSL7m6TtGhAqrYiFg/YNOTT/nBzK3KQeCJRbnxpjJAVZtQ==}
+
   '@lexical/selection@0.42.0':
     resolution: {integrity: sha512-iWTjLA5BSEuUnvWe9Xwu9FSdZFl3Yi0NqalabXKI+7KgCIlIVXE74y4NvWPUSLkSCB/Z1RPKiHmZqZ1vyu/yGQ==}
+
+  '@lexical/selection@0.44.0':
+    resolution: {integrity: sha512-AEyeZJFFr5YRLeqVR+X0QAW19c4Fk4MFAQu52z2gxAyDGTj9xwVJxjfepVpfUp4P9K+sPtJ/yaqfMXH506ksSQ==}
 
   '@lexical/table@0.42.0':
     resolution: {integrity: sha512-GKiZyjQsHDXRckq5VBrOowyvds51WoVRECfDgcl8pqLMnKyEdCa58E7fkSJrr5LS80Scod+Cjn6SBRzOcdsrKg==}
@@ -733,8 +794,14 @@ packages:
   '@lexical/text@0.42.0':
     resolution: {integrity: sha512-hT3EYVtBmONXyXe4TFVgtFcG1tf6JhLEuAf95+cOjgFGFSgvkZ/64BPbKLNTj2/9n6cU7EGPUNNwVigCSECJ2g==}
 
+  '@lexical/text@0.44.0':
+    resolution: {integrity: sha512-1XJD8ZbwaXljTl8k4+jjiopdhnYZm26IJw9Gv8+cIThVC0b6B3JZ/WxH97BMDcSloKvWHFkGiPztxRwNwA29Rw==}
+
   '@lexical/utils@0.42.0':
     resolution: {integrity: sha512-wGNdCW3QWEyVdFiSTLZfFPtiASPyYLcekIiYYZmoRVxVimT/jY+QPfnkO4JYgkO7Z70g/dsg9OhqyQSChQfvkQ==}
+
+  '@lexical/utils@0.44.0':
+    resolution: {integrity: sha512-/D2ptztNevfBJgtkj4uaiYBeRcvSy+1mQj6pNYaCFZIoPJIwl6H5fXwWAvpvr11vcQKP9DEEoXR+V4qkMOA+EA==}
 
   '@lexical/yjs@0.42.0':
     resolution: {integrity: sha512-DplzWnYhfFceGPR+UyDFpZdB287wF/vNOHFuDsBF/nGDdTezvr0Gf60opzyBEF3oXym6p3xTmGygxvO97LZ+vw==}
@@ -872,6 +939,9 @@ packages:
 
   '@preact/signals-core@1.14.0':
     resolution: {integrity: sha512-AowtCcCU/33lFlh1zRFf/u+12rfrhtNakj7UpaGEsmMwUKpKWMVvcktOGcwBBNiB4lWrZWc01LhiyyzVklJyaQ==}
+
+  '@preact/signals-core@1.14.2':
+    resolution: {integrity: sha512-RZHdBj9ZF4n40Rp4jS052EHHjBWf96P9oNdXPfhQTovCuWY9iQn3Gq+gOTJSgBO9A/JBuPfMOWsSX/lIU9Pc/A==}
 
   '@react-hook/latest@1.0.3':
     resolution: {integrity: sha512-dy6duzl+JnAZcDbNTfmaP3xHiKtbXYOaz3G51MGVljh548Y8MWzTr+PHLOfvpypEVW9zwvl+VyKjbWKEVbV1Rg==}
@@ -1177,6 +1247,9 @@ packages:
 
   '@types/sockjs@0.3.36':
     resolution: {integrity: sha512-MK9V6NzAS1+Ud7JV9lJLFqW85VbC9dq3LmwZCuBe4wBDgKC0Kj/jd8Xl+nSviU+Qc3+m7umHHyHg//2KSa0a0Q==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@types/ua-parser-js@0.7.39':
     resolution: {integrity: sha512-P/oDfpofrdtF5xw433SPALpdSchtJmY7nsJItf8h3KXqOslkbySh8zq4dSWXH2oTjRvJ5PczVEoCZPow6GicLg==}
@@ -2066,6 +2139,10 @@ packages:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  eslint-visitor-keys@4.2.1:
+    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   eslint-visitor-keys@5.0.1:
     resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
@@ -2079,6 +2156,10 @@ packages:
     peerDependenciesMeta:
       jiti:
         optional: true
+
+  espree@10.4.0:
+    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   espree@11.2.0:
     resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
@@ -2289,6 +2370,14 @@ packages:
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+  globals@14.0.0:
+    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
+
+  globals@17.6.0:
+    resolution: {integrity: sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==}
+    engines: {node: '>=18'}
 
   globalthis@1.0.4:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
@@ -2725,6 +2814,9 @@ packages:
 
   lexical@0.42.0:
     resolution: {integrity: sha512-GY9Lg3YEIU7nSFaiUlLspZ1fm4NfIcfABaxy9nT+fRVDkX7iV005T5Swil83gXUmxFUNKGal3j+hUxHOUDr+Aw==}
+
+  lexical@0.44.0:
+    resolution: {integrity: sha512-ReDUjRlFgkGoPWzvdjr7s16PUVpHATN+2NH2NiZs+PLlISTaIFFgKil2P467oP3Vg+XgmpDsUgmWZsFJTztYjg==}
 
   lib0@0.2.117:
     resolution: {integrity: sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==}
@@ -3659,6 +3751,10 @@ packages:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
 
+  strip-json-comments@3.1.1:
+    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
+    engines: {node: '>=8'}
+
   style-loader@4.0.0:
     resolution: {integrity: sha512-1V4WqhhZZgjVAVJyt7TdDPZoPBPNHbekX4fWnCJL1yQukhCeZhJySUL+gL9y6sNdN95uEOS83Y55SqHcP7MzLA==}
     engines: {node: '>= 18.12.0'}
@@ -4270,6 +4366,20 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
+  '@eslint/eslintrc@3.3.5':
+    dependencies:
+      ajv: 6.14.0
+      debug: 4.4.3
+      espree: 10.4.0
+      globals: 14.0.0
+      ignore: 5.3.2
+      import-fresh: 3.3.1
+      js-yaml: 4.1.1
+      minimatch: 3.1.5
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@eslint/js@10.0.1(eslint@10.1.0(jiti@2.6.1))':
     optionalDependencies:
       eslint: 10.1.0(jiti@2.6.1)
@@ -4480,9 +4590,38 @@ snapshots:
       '@lexical/utils': 0.42.0
       lexical: 0.42.0
 
+  '@lexical/clipboard@0.44.0':
+    dependencies:
+      '@lexical/extension': 0.44.0
+      '@lexical/html': 0.44.0
+      '@lexical/list': 0.44.0
+      '@lexical/selection': 0.44.0
+      '@lexical/utils': 0.44.0
+      '@types/trusted-types': 2.0.7
+      lexical: 0.44.0
+
   '@lexical/code-core@0.42.0':
     dependencies:
       lexical: 0.42.0
+
+  '@lexical/code-core@0.44.0':
+    dependencies:
+      '@lexical/extension': 0.44.0
+      lexical: 0.44.0
+
+  '@lexical/code-prism@0.44.0':
+    dependencies:
+      '@lexical/code-core': 0.44.0
+      '@lexical/extension': 0.44.0
+      lexical: 0.44.0
+      prismjs: 1.30.0
+
+  '@lexical/code@0.44.0':
+    dependencies:
+      '@lexical/code-core': 0.44.0
+      '@lexical/code-prism': 0.44.0
+      '@lexical/extension': 0.44.0
+      lexical: 0.44.0
 
   '@lexical/devtools-core@0.42.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -4500,11 +4639,22 @@ snapshots:
       '@lexical/extension': 0.42.0
       lexical: 0.42.0
 
+  '@lexical/dragon@0.44.0':
+    dependencies:
+      '@lexical/extension': 0.44.0
+      lexical: 0.44.0
+
   '@lexical/extension@0.42.0':
     dependencies:
       '@lexical/utils': 0.42.0
       '@preact/signals-core': 1.14.0
       lexical: 0.42.0
+
+  '@lexical/extension@0.44.0':
+    dependencies:
+      '@lexical/utils': 0.44.0
+      '@preact/signals-core': 1.14.2
+      lexical: 0.44.0
 
   '@lexical/hashtag@0.42.0':
     dependencies:
@@ -4524,11 +4674,24 @@ snapshots:
       '@lexical/utils': 0.42.0
       lexical: 0.42.0
 
+  '@lexical/html@0.44.0':
+    dependencies:
+      '@lexical/extension': 0.44.0
+      '@lexical/selection': 0.44.0
+      '@lexical/utils': 0.44.0
+      lexical: 0.44.0
+
   '@lexical/link@0.42.0':
     dependencies:
       '@lexical/extension': 0.42.0
       '@lexical/utils': 0.42.0
       lexical: 0.42.0
+
+  '@lexical/link@0.44.0':
+    dependencies:
+      '@lexical/extension': 0.44.0
+      '@lexical/utils': 0.44.0
+      lexical: 0.44.0
 
   '@lexical/list@0.42.0':
     dependencies:
@@ -4536,6 +4699,12 @@ snapshots:
       '@lexical/selection': 0.42.0
       '@lexical/utils': 0.42.0
       lexical: 0.42.0
+
+  '@lexical/list@0.44.0':
+    dependencies:
+      '@lexical/extension': 0.44.0
+      '@lexical/utils': 0.44.0
+      lexical: 0.44.0
 
   '@lexical/mark@0.42.0':
     dependencies:
@@ -4551,6 +4720,16 @@ snapshots:
       '@lexical/text': 0.42.0
       '@lexical/utils': 0.42.0
       lexical: 0.42.0
+
+  '@lexical/markdown@0.44.0':
+    dependencies:
+      '@lexical/code-core': 0.44.0
+      '@lexical/link': 0.44.0
+      '@lexical/list': 0.44.0
+      '@lexical/rich-text': 0.44.0
+      '@lexical/text': 0.44.0
+      '@lexical/utils': 0.44.0
+      lexical: 0.44.0
 
   '@lexical/offset@0.42.0':
     dependencies:
@@ -4602,9 +4781,21 @@ snapshots:
       '@lexical/utils': 0.42.0
       lexical: 0.42.0
 
+  '@lexical/rich-text@0.44.0':
+    dependencies:
+      '@lexical/clipboard': 0.44.0
+      '@lexical/dragon': 0.44.0
+      '@lexical/selection': 0.44.0
+      '@lexical/utils': 0.44.0
+      lexical: 0.44.0
+
   '@lexical/selection@0.42.0':
     dependencies:
       lexical: 0.42.0
+
+  '@lexical/selection@0.44.0':
+    dependencies:
+      lexical: 0.44.0
 
   '@lexical/table@0.42.0':
     dependencies:
@@ -4617,10 +4808,19 @@ snapshots:
     dependencies:
       lexical: 0.42.0
 
+  '@lexical/text@0.44.0':
+    dependencies:
+      lexical: 0.44.0
+
   '@lexical/utils@0.42.0':
     dependencies:
       '@lexical/selection': 0.42.0
       lexical: 0.42.0
+
+  '@lexical/utils@0.44.0':
+    dependencies:
+      '@lexical/selection': 0.44.0
+      lexical: 0.44.0
 
   '@lexical/yjs@0.42.0(yjs@13.6.30)':
     dependencies:
@@ -4785,6 +4985,8 @@ snapshots:
   '@popperjs/core@2.11.8': {}
 
   '@preact/signals-core@1.14.0': {}
+
+  '@preact/signals-core@1.14.2': {}
 
   '@react-hook/latest@1.0.3(react@19.2.4)':
     dependencies:
@@ -5085,6 +5287,8 @@ snapshots:
   '@types/sockjs@0.3.36':
     dependencies:
       '@types/node': 20.19.37
+
+  '@types/trusted-types@2.0.7': {}
 
   '@types/ua-parser-js@0.7.39': {}
 
@@ -6147,6 +6351,8 @@ snapshots:
 
   eslint-visitor-keys@3.4.3: {}
 
+  eslint-visitor-keys@4.2.1: {}
+
   eslint-visitor-keys@5.0.1: {}
 
   eslint@10.1.0(jiti@2.6.1):
@@ -6185,6 +6391,12 @@ snapshots:
       jiti: 2.6.1
     transitivePeerDependencies:
       - supports-color
+
+  espree@10.4.0:
+    dependencies:
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
+      eslint-visitor-keys: 4.2.1
 
   espree@11.2.0:
     dependencies:
@@ -6424,6 +6636,10 @@ snapshots:
       minimatch: 3.1.5
       once: 1.4.0
       path-is-absolute: 1.0.1
+
+  globals@14.0.0: {}
+
+  globals@17.6.0: {}
 
   globalthis@1.0.4:
     dependencies:
@@ -6869,6 +7085,8 @@ snapshots:
       type-check: 0.4.0
 
   lexical@0.42.0: {}
+
+  lexical@0.44.0: {}
 
   lib0@0.2.117:
     dependencies:
@@ -7855,6 +8073,8 @@ snapshots:
       ansi-regex: 5.0.1
 
   strip-bom@3.0.0: {}
+
+  strip-json-comments@3.1.1: {}
 
   style-loader@4.0.0(webpack@5.105.4(@swc/core@1.15.21(@swc/helpers@0.5.20))):
     dependencies:

--- a/src/components/calc/CalcdexContext/useCalcdexPresets.ts
+++ b/src/components/calc/CalcdexContext/useCalcdexPresets.ts
@@ -15,6 +15,7 @@ import {
   calcPresetCalcdexId,
   guessServerLegacySpread,
   guessServerSpread,
+  guessUnrestrictedSpread,
   populateStatsTable,
 } from '@showdex/utils/calc';
 import { formatId, nonEmptyObject } from '@showdex/utils/core';
@@ -245,7 +246,7 @@ export const useCalcdexPresets = (
           if (!preset?.calcdexId && !pokemon.transformedForme) {
             const guessedSpread = state.legacy
               ? guessServerLegacySpread(state.format, pokemon)
-              : guessServerSpread(state.format, pokemon);
+              : guessUnrestrictedSpread(state.format, pokemon);
 
             if (nonEmptyObject(guessedSpread)) {
               preset = {

--- a/src/consts/dex/natures.ts
+++ b/src/consts/dex/natures.ts
@@ -68,3 +68,18 @@ export const PokemonCommonNatures: Showdown.NatureName[] = [
   'Sassy',
   'Hardy',
 ];
+
+export const PokemonNatureLookup: Partial<Record<
+  `${Showdown.StatNameNoHp}:${Showdown.StatNameNoHp}`,
+  Showdown.NatureName
+>> = {};
+
+for (const nature of PokemonNatures) {
+  const [plus, minus] = PokemonNatureBoosts[nature];
+
+  if (!plus || !minus) {
+    continue;
+  }
+
+  PokemonNatureLookup[`${plus}:${minus}`] = nature;
+}

--- a/src/utils/calc/guessUnrestrictedSpread.ts
+++ b/src/utils/calc/guessUnrestrictedSpread.ts
@@ -207,7 +207,7 @@ export const guessUnrestrictedSpread = (
     spe: 0,
   };
 
-  const plusMaxes: Showdown.StatsTable = {
+  const plusMins: Showdown.StatsTable = {
     hp: 0,
     atk: 0,
     def: 0,
@@ -258,12 +258,12 @@ export const guessUnrestrictedSpread = (
       (n) => PokemonNatureBoosts[n][1] === stat,
     )!;
 
-    const plusMax = calcPokemonStat(
+    const plusMin = calcPokemonStat(
       gen,
       stat,
       baseStats[stat],
-      31,
-      252,
+      0,
+      0,
       pokemon.level,
       boostedNature,
     );
@@ -280,7 +280,7 @@ export const guessUnrestrictedSpread = (
 
     statMins[stat] = neutralMin;
     statMaxes[stat] = neutralMax;
-    plusMaxes[stat] = plusMax;
+    plusMins[stat] = plusMin;
     minusMaxes[stat] = minusMax;
 
     const observed = serverStats[stat];
@@ -296,7 +296,7 @@ export const guessUnrestrictedSpread = (
     }
 
     // allowed boosted
-    if (observed <= plusMax) {
+    if (observed >= plusMin) {
       allowedPlus.push(stat);
     }
 

--- a/src/utils/calc/guessUnrestrictedSpread.ts
+++ b/src/utils/calc/guessUnrestrictedSpread.ts
@@ -315,51 +315,29 @@ export const guessUnrestrictedSpread = (
 
   let chosenNature: Showdown.NatureName = 'Hardy';
 
-  if (plusStat && minusStat) {
-    const lookup = PokemonNatureLookup[`${plusStat}:${minusStat}`];
+  const candidateMinus = minusStat || allowedMinus
+    .filter((s) => s !== plusStat)
+    .sort((a, b) => serverStats[a] - serverStats[b])[0];
 
-    if (!lookup) {
-      return null;
-    }
+  const candidatePlus = plusStat || allowedPlus
+    .filter(
+      (s) => s !== minusStat &&
+        // Stat jumps for enhanced stats always skip 10 mod 11
+        (serverStats[s] + 1) % 11 !== 0,
+    )
+    .sort((a, b) => serverStats[b] - serverStats[a])[0];
 
-    chosenNature = lookup;
-  } else if (plusStat) {
-    const candidateMinus = allowedMinus
-      .filter((s) => s !== plusStat)
-      .sort((a, b) => serverStats[a] - serverStats[b])[0];
-
-    if (!candidateMinus) {
-      return null;
-    }
-
-    const lookup = PokemonNatureLookup[`${plusStat}:${candidateMinus}`];
-
-    if (!lookup) {
-      return null;
-    }
-
-    chosenNature = lookup;
-  } else if (minusStat) {
-    const candidatePlus = allowedPlus
-      .filter(
-        (s) => s !== minusStat &&
-          // Stat jumps for enhanced stats always skip 10 mod 11
-          (serverStats[s] + 1) % 11 !== 0,
-      )
-      .sort((a, b) => serverStats[b] - serverStats[a])[0];
-
-    if (!candidatePlus) {
-      return null;
-    }
-
-    const lookup = PokemonNatureLookup[`${candidatePlus}:${minusStat}`];
-
-    if (!lookup) {
-      return null;
-    }
-
-    chosenNature = lookup;
+  if (!candidatePlus || !candidateMinus) {
+    return null;
   }
+
+  const lookup = PokemonNatureLookup[`${candidatePlus}:${candidateMinus}`];
+
+  if (!lookup) {
+    return null;
+  }
+
+  chosenNature = lookup;
 
   guessedSpread.nature = chosenNature;
 

--- a/src/utils/calc/guessUnrestrictedSpread.ts
+++ b/src/utils/calc/guessUnrestrictedSpread.ts
@@ -1,0 +1,405 @@
+import { type GenerationNum } from '@smogon/calc';
+import {
+ PokemonCommonNatures, PokemonNatureBoosts, PokemonStatNames, PokemonNatureLookup,
+} from '@showdex/consts/dex';
+import { type CalcdexPokemon, type CalcdexPokemonPreset } from '@showdex/interfaces/calc';
+import { env, nonEmptyObject } from '@showdex/utils/core';
+import { logger } from '@showdex/utils/debug';
+import { detectGenFromFormat, detectLegacyGen } from '@showdex/utils/dex';
+import { calcPokemonStat } from './calcPokemonStat';
+
+const l = logger('@showdex/utils/calc/guessUnrestrictedSpread()');
+
+/**
+ * Attempts to guess the spread (nature/EVs/IVs) of the passed-in `pokemon`.
+ *
+ * * Client unfortunately only gives us the *final* stats after the spread has been applied.
+ * * Nature Selection is done first
+ *   - If a stat is too high or too low to be achieved with a neutral nature, we know it has to be modified by nature accordingly
+ *   - If no stat *needs* to be boosted, the highest *final* stat will be chosen to be boosted to save the most EVs
+ *   - And accordingly the lowest stat will be hindered to lose the most EVs
+ * * Stat jumps are taken into consideration, with any 10 mod 11 stat value being skipped if boosted by nature
+ * * If the spread is legal with the allowed total EV count, then these choices are optimal to keep under the allowance
+ * * If the spread is not legal, the stats are still derived, specifically motivated to make Hackmons Cup more functional
+ *
+ * @since 1.3.0
+ */
+
+const solveStat = (
+  gen: GenerationNum,
+  stat: Showdown.StatName,
+  baseStat: number,
+  observedStat: number,
+  level: number,
+  nature: Showdown.NatureName,
+): {
+  iv: number;
+  ev: number;
+} | null => {
+  // HP change to formula
+  let offset = 5;
+  if (stat === 'hp') {
+    offset = level + 10;
+  }
+
+  let natureMultiplier = 1;
+
+  if (nature && nature in PokemonNatureBoosts) {
+    const [
+      plus,
+      minus,
+    ] = PokemonNatureBoosts[nature];
+
+    if (plus && stat === plus) {
+      natureMultiplier = 1.1;
+    }
+
+    if (minus && stat === minus) {
+      natureMultiplier = 0.9;
+    }
+  }
+
+  // target X for IV EV combo
+  const internal = Math.ceil(observedStat / natureMultiplier);
+
+  let X: number;
+
+  if (level === 100) {
+    X = Math.ceil(internal - (2 * baseStat) - offset);
+  } else {
+    X = Math.ceil(
+      ((internal - offset) * 100) / level - (2 * baseStat),
+    );
+  }
+
+  // impossible stat
+  if (X < 0 || X > 94) {
+    return null;
+  }
+
+  const iv = Math.min(31, X);
+  const ev = Math.max(0, Math.min(252, (X - iv) * 4));
+
+  // verify
+  const reconstructed = calcPokemonStat(
+    gen,
+    stat,
+    baseStat,
+    iv,
+    ev,
+    level,
+    nature,
+  );
+
+  if (reconstructed !== observedStat) {
+    return null;
+  }
+
+  return {
+    iv,
+    ev,
+  };
+};
+
+export const guessUnrestrictedSpread = (
+  format: string | GenerationNum,
+  pokemon: CalcdexPokemon,
+  knownNature?: Showdown.NatureName,
+): Partial<CalcdexPokemonPreset> => {
+  const gen = typeof format === 'string'
+    ? detectGenFromFormat(format, env.int<GenerationNum>('calcdex-default-gen'))
+    : format;
+
+  if (detectLegacyGen(gen)) {
+    if (__DEV__) {
+      l.warn(
+        'Cannot guess a legacy spread; use guessServerLegacySpread() instead.',
+        '\n', 'format', format, 'gen', gen,
+        '\n', 'pokemon', pokemon,
+        '\n', '(You will only see this warning on development.)',
+      );
+    }
+
+    return null;
+  }
+
+  if (!pokemon?.speciesForme) {
+    if (__DEV__) {
+      l.warn(
+        'Received an invalid Pokemon', pokemon?.ident || pokemon?.speciesForme,
+        '\n', 'format', format, 'gen', gen,
+        '\n', 'pokemon', pokemon,
+        '\n', '(You will only see this warning on development.)',
+      );
+    }
+
+    return null;
+  }
+
+  if (!nonEmptyObject(pokemon.baseStats)) {
+    if (__DEV__) {
+      l.warn(
+        'No baseStats were found for Pokemon', pokemon.ident || pokemon.speciesForme,
+        '\n', 'format', format, 'gen', gen,
+        '\n', 'pokemon', pokemon,
+        '\n', '(You will only see this warning on development.)',
+      );
+    }
+
+    return null;
+  }
+
+  if (__DEV__ && pokemon.source !== 'server') {
+    l.warn(
+      'Attempting to guess the spread of non-server Pokemon', pokemon.ident || pokemon.speciesForme,
+      '\n', 'format', format, 'gen', gen,
+      '\n', 'pokemon', pokemon,
+      '\n', '(You will only see this warning on development.)',
+    );
+  }
+
+  const {
+    baseStats,
+    serverStats,
+  } = pokemon;
+
+  // 0 HP in serverStats indicates that the server hasn't reported the Pokemon's actual maxhp
+  // (probably because they're dead, which is just dandy LOL)
+  const ignoreHp = !serverStats.hp;
+
+  // this is the spread that we'll return after guessing
+  const guessedSpread: Partial<CalcdexPokemonPreset> = {
+    nature: knownNature || null,
+    ivs: {},
+    evs: {},
+  };
+
+  const natureCombinations = guessedSpread?.nature
+    ? [
+      guessedSpread.nature,
+      ...PokemonCommonNatures.filter((n) => n !== guessedSpread.nature),
+    ].filter(Boolean)
+    : PokemonCommonNatures;
+
+  // logs of each guess (only on development)
+  const logs: string[] = [];
+
+  const forcedPlus: Showdown.StatNameNoHp[] = [];
+  const forcedMinus: Showdown.StatNameNoHp[] = [];
+  const allowedPlus: Showdown.StatNameNoHp[] = [];
+  const allowedMinus: Showdown.StatNameNoHp[] = [];
+
+  const statMins: Showdown.StatsTable = {
+    hp: 0,
+    atk: 0,
+    def: 0,
+    spa: 0,
+    spd: 0,
+    spe: 0,
+  };
+
+  const statMaxes: Showdown.StatsTable = {
+    hp: 0,
+    atk: 0,
+    def: 0,
+    spa: 0,
+    spd: 0,
+    spe: 0,
+  };
+
+  const plusMaxes: Showdown.StatsTable = {
+    hp: 0,
+    atk: 0,
+    def: 0,
+    spa: 0,
+    spd: 0,
+    spe: 0,
+  };
+
+  const minusMaxes: Showdown.StatsTable = {
+    hp: 0,
+    atk: 0,
+    def: 0,
+    spa: 0,
+    spd: 0,
+    spe: 0,
+  };
+
+  for (const stat of PokemonStatNames) {
+    if (stat === 'hp') {
+      continue;
+    }
+
+    const neutralMin = calcPokemonStat(
+      gen,
+      stat,
+      baseStats[stat],
+      0,
+      0,
+      pokemon.level,
+      'Hardy',
+    );
+
+    const neutralMax = calcPokemonStat(
+      gen,
+      stat,
+      baseStats[stat],
+      31,
+      252,
+      pokemon.level,
+      'Hardy',
+    );
+
+    const boostedNature = natureCombinations.find(
+      (n) => PokemonNatureBoosts[n][0] === stat,
+    )!;
+
+    const hinderedNature = natureCombinations.find(
+      (n) => PokemonNatureBoosts[n][1] === stat,
+    )!;
+
+    const plusMax = calcPokemonStat(
+      gen,
+      stat,
+      baseStats[stat],
+      31,
+      252,
+      pokemon.level,
+      boostedNature,
+    );
+
+    const minusMax = calcPokemonStat(
+      gen,
+      stat,
+      baseStats[stat],
+      31,
+      252,
+      pokemon.level,
+      hinderedNature,
+    );
+
+    statMins[stat] = neutralMin;
+    statMaxes[stat] = neutralMax;
+    plusMaxes[stat] = plusMax;
+    minusMaxes[stat] = minusMax;
+
+    const observed = serverStats[stat];
+
+    // forced boosted
+    if (observed > neutralMax) {
+      forcedPlus.push(stat);
+    }
+
+    // forced hindered
+    if (observed < neutralMin) {
+      forcedMinus.push(stat);
+    }
+
+    // allowed boosted
+    if (observed <= plusMax) {
+      allowedPlus.push(stat);
+    }
+
+    // allowed hindered
+    if (observed <= minusMax) {
+      allowedMinus.push(stat);
+    }
+  }
+
+  if (forcedPlus.length > 1 || forcedMinus.length > 1) {
+    return null;
+  }
+
+  const plusStat = forcedPlus[0];
+  const minusStat = forcedMinus[0];
+
+  let chosenNature: Showdown.NatureName = 'Hardy';
+
+  if (plusStat && minusStat) {
+    const lookup = PokemonNatureLookup[`${plusStat}:${minusStat}`];
+
+    if (!lookup) {
+      return null;
+    }
+
+    chosenNature = lookup;
+  } else if (plusStat) {
+    const candidateMinus = allowedMinus
+      .filter((s) => s !== plusStat)
+      .sort((a, b) => serverStats[a] - serverStats[b])[0];
+
+    if (!candidateMinus) {
+      return null;
+    }
+
+    const lookup = PokemonNatureLookup[`${plusStat}:${candidateMinus}`];
+
+    if (!lookup) {
+      return null;
+    }
+
+    chosenNature = lookup;
+  } else if (minusStat) {
+    const candidatePlus = allowedPlus
+      .filter(
+        (s) => s !== minusStat &&
+          // Stat jumps for enhanced stats always skip 10 mod 11
+          (serverStats[s] + 1) % 11 !== 0,
+      )
+      .sort((a, b) => serverStats[b] - serverStats[a])[0];
+
+    if (!candidatePlus) {
+      return null;
+    }
+
+    const lookup = PokemonNatureLookup[`${candidatePlus}:${minusStat}`];
+
+    if (!lookup) {
+      return null;
+    }
+
+    chosenNature = lookup;
+  }
+
+  guessedSpread.nature = chosenNature;
+
+  for (const stat of PokemonStatNames) {
+    if (ignoreHp && stat === 'hp') {
+      continue;
+    }
+
+    const spread = solveStat(
+      gen,
+      stat,
+      baseStats[stat],
+      serverStats[stat],
+      pokemon.level,
+      guessedSpread.nature,
+    );
+    if (spread) {
+      guessedSpread.ivs[stat] = spread.iv;
+      guessedSpread.evs[stat] = spread.ev;
+    }
+  }
+
+  if (!nonEmptyObject({ ...guessedSpread.ivs, ...guessedSpread.evs })) {
+      l.debug(
+        'Failed to find the actual spread for Pokemon', pokemon.ident || pokemon.speciesForme,
+        '\n', 'guessedSpread', guessedSpread,
+        '\n', 'serverStats', serverStats,
+        '\n', 'pokemon', pokemon,
+        '\n', 'logs', logs,
+      );
+    }
+
+    // } else {
+    //   l.debug(
+    //     'Returning the best guess of the spread for Pokemon', pokemon.ident || pokemon.speciesForme,
+    //     '\n', 'guessedSpread', guessedSpread,
+    //     '\n', 'serverStats', serverStats,
+    //     '\n', 'pokemon', pokemon,
+    //   );
+    // }
+
+    return guessedSpread;
+};

--- a/src/utils/calc/index.ts
+++ b/src/utils/calc/index.ts
@@ -23,6 +23,7 @@ export * from './getMatchupRange';
 export * from './getMoveOverrideDefaults';
 export * from './guessServerLegacySpread';
 export * from './guessServerSpread';
+export * from './guessUnrestrictedSpread';
 export * from './hasMoveOverrides';
 export * from './populateStatsTable';
 export * from './parseMatchupDescription';


### PR DESCRIPTION
Hackmons cup format often gets default spreads on user's pokemon likely because the guessing algorithm rejects spreads with too many evs. guessUnrestrictedSpreads restores functionality there, also implements a faster algorithm to detect most efficient nature first, which should still be compliant with ev totals if the base stats are legally generated from the ev restriction.