### PR TITLE
Removed firefox links

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 <br>
 
-Officially supported on [**Chrome**](https://chrome.google.com/webstore/detail/dabpnahpcemkfbgfbmegmncjllieilai) (+ any native [**Chromium**](https://chromium.org/Home) browser, like **Arc**, **Edge** & **Brave**), [**Opera**](https://addons.opera.com/en/extensions/details/showdex) & **Firefox** (via manual install.
+Officially supported on [**Chrome**](https://chrome.google.com/webstore/detail/dabpnahpcemkfbgfbmegmncjllieilai) (+ any native [**Chromium**](https://chromium.org/Home) browser, like **Arc**, **Edge** & **Brave**), [**Opera**](https://addons.opera.com/en/extensions/details/showdex) & **Firefox** (via manual install).
 
 <details>
   <summary>

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   <thead>
     <tr>
       <th align="center">&nbsp;Currently <a href="https://github.com/doshidak/showdex/releases/tag/v1.3.0">v1.3.0</a>&nbsp;</th>
-      <th align="center">&nbsp;Install on <a href="https://chrome.google.com/webstore/detail/dabpnahpcemkfbgfbmegmncjllieilai">Chrome</a> · <a href="https://chrome.google.com/webstore/detail/dabpnahpcemkfbgfbmegmncjllieilai">Opera</a> · <a href="https://addons.mozilla.org/en-US/firefox/addon/showdex">Firefox</a> · <a href="https://apps.apple.com/us/app/enhanced-tooltips-for-showdown/id1612964050">Safari</a>&nbsp;</th>
+      <th align="center">&nbsp;Install on <a href="https://chrome.google.com/webstore/detail/dabpnahpcemkfbgfbmegmncjllieilai">Chrome</a> · <a href="https://chrome.google.com/webstore/detail/dabpnahpcemkfbgfbmegmncjllieilai">Opera</a> · <a href="https://apps.apple.com/us/app/enhanced-tooltips-for-showdown/id1612964050">Safari</a>&nbsp;</th>
       <th align="center">&nbsp;Discuss on <a href="https://smogon.com/forums/threads/showdex-an-auto-updating-damage-calculator-built-into-showdown.3707265">Smogon</a> · <a href="https://discord.gg/2PXVGGCkm2">Discord</a></th>
     </tr>
   </thead>
@@ -22,7 +22,7 @@
 
 <br>
 
-Officially supported on [**Chrome**](https://chrome.google.com/webstore/detail/dabpnahpcemkfbgfbmegmncjllieilai) (+ any native [**Chromium**](https://chromium.org/Home) browser, like **Arc**, **Edge** & **Brave**), [**Opera**](https://addons.opera.com/en/extensions/details/showdex) & [**Firefox**](https://addons.mozilla.org/en-US/firefox/addon/showdex).
+Officially supported on [**Chrome**](https://chrome.google.com/webstore/detail/dabpnahpcemkfbgfbmegmncjllieilai) (+ any native [**Chromium**](https://chromium.org/Home) browser, like **Arc**, **Edge** & **Brave**), [**Opera**](https://addons.opera.com/en/extensions/details/showdex) & **Firefox** (via manual install.
 
 <details>
   <summary>


### PR DESCRIPTION
Removed firefox links as there's no official release of showdex on the firefox add-on store